### PR TITLE
improve(Relayer): Allow user to skip early exit for "un-finalized" deposits if in simulation mode

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -275,7 +275,7 @@ export class Relayer {
       });
       // If we're in simulation mode, skip this early exit so that the user can evaluate
       // the full simulation run.
-      if (this.config.sendingRelaysEnabled)  {
+      if (this.config.sendingRelaysEnabled) {
         return;
       }
     }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -15,6 +15,7 @@ import {
   toBNWei,
   winston,
   fixedPointAdjustment,
+  CHAIN_IDs,
 } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 import { RelayerConfig } from "./RelayerConfig";
@@ -273,9 +274,9 @@ export class Relayer {
         maxBlockNumber,
         transactionHash: deposit.transactionHash,
       });
-      // If we're in simulation mode, skip this early exit so that the user can evaluate
+      // If we're in simulation mode on mainnet, skip this early exit so that the user can evaluate
       // the full simulation run.
-      if (this.config.sendingRelaysEnabled) {
+      if (this.config.sendingRelaysEnabled || this.clients.hubPoolClient.chainId !== CHAIN_IDs.MAINNET) {
         return;
       }
     }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -15,7 +15,6 @@ import {
   toBNWei,
   winston,
   fixedPointAdjustment,
-  CHAIN_IDs,
 } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 import { RelayerConfig } from "./RelayerConfig";
@@ -274,9 +273,9 @@ export class Relayer {
         maxBlockNumber,
         transactionHash: deposit.transactionHash,
       });
-      // If we're in simulation mode on mainnet, skip this early exit so that the user can evaluate
+      // If we're in simulation mode, skip this early exit so that the user can evaluate
       // the full simulation run.
-      if (this.config.sendingRelaysEnabled || this.clients.hubPoolClient.chainId !== CHAIN_IDs.MAINNET) {
+      if (this.config.sendingRelaysEnabled) {
         return;
       }
     }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -273,7 +273,11 @@ export class Relayer {
         maxBlockNumber,
         transactionHash: deposit.transactionHash,
       });
-      return;
+      // If we're in simulation mode, skip this early exit so that the user can evaluate
+      // the full simulation run.
+      if (this.config.sendingRelaysEnabled)  {
+        return;
+      }
     }
 
     // If depositor is on the slow deposit list, then send a zero fill to initiate a slow relay and return early.

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -406,7 +406,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
           minDepositConfirmations: {
             default: { [originChainId]: 10 }, // This needs to be set large enough such that the deposit is ignored.
           },
-          sendingRelaysEnabled: false,
+          sendingRelaysEnabled: true,
         } as unknown as RelayerConfig
       );
 


### PR DESCRIPTION
I  manually comment out this line a lot when testing the relayer locally because I want to see how the relayer would evaluate a 
deposit's 
profitability and pick a repayment chain without sending a deposit.
