### PR TITLE
refactor: Remove top-level bot loop (take two)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -57,11 +57,10 @@ if (require.main === module) {
 
   const args = minimist(process.argv.slice(2), opts);
 
+  let exitCode = 0;
   run(args)
-    .then(() => {
-      exit(0);
-    })
     .catch(async (error) => {
+      exitCode = 1;
       logger.error({
         at: cmd ?? "unknown process",
         message: "There was an execution error!",
@@ -72,6 +71,6 @@ if (require.main === module) {
         notificationPath: "across-error",
       });
       await delay(5); // Wait for transports to flush. May or may not be necessary.
-      exit(1);
-    });
+    })
+  .finally(() => exit(exitCode));
 }

--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,5 @@
 import minimist from "minimist";
-import { CommonConfig } from "./src/common";
-import {
-  AnyObject,
-  config,
-  delay,
-  retrieveSignerFromCLIArgs,
-  help,
-  Logger,
-  processCrash,
-  usage,
-  winston,
-} from "./src/utils";
+import { config, delay, exit, retrieveSignerFromCLIArgs, help, Logger, usage, winston } from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
@@ -18,11 +7,10 @@ import { runFinalizer } from "./src/finalizer";
 import { version } from "./package.json";
 
 let logger: winston.Logger;
+let cmd: string;
 
 export async function run(args: { [k: string]: boolean | string }): Promise<void> {
   logger = Logger;
-
-  const config = new CommonConfig(process.env);
 
   const cmds = {
     dataworker: runDataworker,
@@ -35,7 +23,7 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
   // todo Make the mode of operation an operand, rather than an option.
   // i.e. ts-node ./index.ts [options] <relayer|...>
   // Note: ts does not produce a narrow type from Object.keys, so we have to help.
-  const cmd = Object.keys(cmds).find((_cmd) => !!args[_cmd]);
+  cmd = Object.keys(cmds).find((_cmd) => !!args[_cmd]);
 
   if (cmd === "help") {
     cmds[cmd]();
@@ -47,19 +35,10 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
     // todo: Update usage() to provide a hint that wallet is missing/malformed.
     usage(""); // no return
   } else {
+    // One global signer for use with a specific per-chain provider.
+    // todo: Support a void signer for monitor mode (only) if no wallet was supplied.
     const signer = await retrieveSignerFromCLIArgs();
-    do {
-      try {
-        // One global signer for use with a specific per-chain provider.
-        // todo: Support a void signer for monitor mode (only) if no wallet was supplied.
-        await cmds[cmd](logger, signer);
-      } catch (error) {
-        if (await processCrash(logger, cmd, config.pollingDelay, error as AnyObject)) {
-          // eslint-disable-next-line no-process-exit
-          process.exit(1);
-        }
-      }
-    } while (config.pollingDelay !== 0);
+    await cmds[cmd](logger, signer);
   }
 }
 
@@ -80,17 +59,19 @@ if (require.main === module) {
 
   run(args)
     .then(() => {
-      // eslint-disable-next-line no-process-exit
-      process.exit(0);
+      exit(0);
     })
     .catch(async (error) => {
       logger.error({
-        at: "InfrastructureEntryPoint",
-        message: "There was an error in the main entry point!",
+        at: cmd ?? "unknown process",
+        message: "There was an execution error!",
+        reason: error,
+        e: error,
         error,
+        args,
         notificationPath: "across-error",
       });
-      await delay(5);
-      await run(args);
+      await delay(5); // Wait for transports to flush. May or may not be necessary.
+      exit(1);
     });
 }

--- a/index.ts
+++ b/index.ts
@@ -72,5 +72,5 @@ if (require.main === module) {
       });
       await delay(5); // Wait for transports to flush. May or may not be necessary.
     })
-  .finally(() => exit(exitCode));
+    .finally(() => exit(exitCode));
 }

--- a/src/utils/ExecutionUtils.ts
+++ b/src/utils/ExecutionUtils.ts
@@ -1,4 +1,9 @@
-import { AnyObject, delay, winston } from "./";
+import { delay, winston } from "./";
+
+export function exit(code: number) {
+  // eslint-disable-next-line no-process-exit
+  process.exit(code);
+}
 
 export async function processEndPollingLoop(
   logger: winston.Logger,
@@ -13,28 +18,6 @@ export async function processEndPollingLoop(
 
   logger.debug({ at: `${fileName}#index`, message: `End of execution loop - waiting polling delay ${pollingDelay}s` });
   await delay(pollingDelay);
-  return false;
-}
-
-export async function processCrash(
-  logger: winston.Logger,
-  fileName: string,
-  pollingDelay: number,
-  error: AnyObject
-): Promise<boolean> {
-  logger.error({
-    at: `${fileName}#index`,
-    message: `There was an execution error! ${pollingDelay != 0 ? "Re-running loop" : ""}`,
-    reason: error,
-    e: error,
-    error,
-    notificationPath: "across-error",
-  });
-  await delay(5);
-  if (pollingDelay === 0) {
-    return true;
-  }
-
   return false;
 }
 


### PR DESCRIPTION
This change was previously merged and backed out shortly after because it was seen to result in some bot instances hanging. This is almost certainly because the original commit removed two instances of process.exit(), and replaced them with prococess.exitCode = <X>. There appear to be some instances where the bot can have some dangling promises that take a long time to resolve, or that don't resolve for some reason. Replaying the change, but without removing the process.exit() calls should be OK.