### PR TITLE
feat(ProviderUtils): Support websocket provider definitions

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -710,15 +710,18 @@ export async function getProvider(chainId: number, logger?: winston.Logger, useC
   return provider;
 }
 
-export function getNodeUrlList(chainId: number, quorum = 1): string[] {
+export function getNodeUrlList(chainId: number, quorum = 1, protocol: "https" | "wss" = "https"): string[] {
   const resolveUrls = (): string[] => {
-    const providers = process.env[`RPC_PROVIDERS_${chainId}`] ?? process.env["RPC_PROVIDERS"];
+    const [envPrefix, providerPrefix] =
+      protocol === "https" ? ["RPC_PROVIDERS", "RPC_PROVIDER"] : ["RPC_WS_PROVIDERS", "RPC_WS_PROVIDER"];
+
+    const providers = process.env[`${envPrefix}_${chainId}`] ?? process.env[envPrefix];
     if (providers === undefined) {
       throw new Error(`No RPC providers defined for chainId ${chainId}`);
     }
 
     const nodeUrls = providers.split(",").map((provider) => {
-      const envVar = `RPC_PROVIDER_${provider}_${chainId}`;
+      const envVar = `${providerPrefix}_${provider}_${chainId}`;
       const url = process.env[envVar];
       if (url === undefined) {
         throw new Error(`Missing RPC provider URL for chain ${chainId} (${envVar})`);


### PR DESCRIPTION
This change tweaks env parsing to permit websocket providers to be defined. Websocket providers are identified by the _WS tag embedded in the name of the env var. This change is compatible with the existing syntax. For example:

  Normal HTTPS provider: RPC_PROVIDERS_<chain-id>
  Websocket provider:    RPC_WS_PROVIDERS_<chain-id>

Longer example:

  \# Identify the default providers to be used.
  RPC_WS_PROVIDERS=INFURA,ALCHEMY

  \# Identify a specific provider to be used for zkSync.
  RPC_WS_PROVIDERS_324=BLOCKPI

  \# Define all websocket endpoints for INFURA
  RPC_WS_PROVIDER_INFURA_1=wss://...
  RPC_WS_PROVIDER_INFURA_10=wss://...
  RPC_WS_PROVIDER_INFURA_137=wss://...

  \# Define all websocket endpoints for ALCHEMY.
  RPC_WS_PROVIDER_ALCHEMY_1=wss://...
  RPC_WS_PROVIDER_ALCHEMY_10=wss://...
  RPC_WS_PROVIDER_ALCHEMY_137=wss://...

  \# Special all websocket endpoints for BLOCKPI.
  RPC_WS_PROVIDER_BLOCKPI_324=wss://...