### PR TITLE
improve(finalizer): improve finalizer performance

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -61,7 +61,6 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
     message: `Time to update non-spoke clients: ${(performance.now() - loopStart) / 1000}s`,
   });
   loopStart = performance.now();
-
   let bundleDataToPersist: BundleDataToPersistToDALayerType | undefined = undefined;
   try {
     logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
@@ -108,7 +107,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         fromBlocks,
         toBlocks
       );
-
+      const dataworkerFunctionLoopTimerStart = performance.now();
       // Validate and dispute pending proposal before proposing a new one
       if (config.disputerEnabled) {
         await dataworker.validatePendingRootBundle(spokePoolClients, config.sendingDisputesEnabled, fromBlocks);
@@ -185,11 +184,14 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         });
       }
 
+      const dataworkerFunctionLoopTimerEnd = performance.now();
       logger.debug({
         at: "Dataworker#index",
         message: `Time to update spoke pool clients and run dataworker function: ${
           (performance.now() - loopStart) / 1000
         }s`,
+        timeToLoadSpokes: (dataworkerFunctionLoopTimerStart - loopStart) / 1000,
+        timeToRunDataworkerFunctions: (dataworkerFunctionLoopTimerEnd - dataworkerFunctionLoopTimerStart) / 1000,
       });
       loopStart = performance.now();
 

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -187,11 +187,13 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       const dataworkerFunctionLoopTimerEnd = performance.now();
       logger.debug({
         at: "Dataworker#index",
-        message: `Time to update spoke pool clients and run dataworker function: ${
+        message: `Time to update spoke pool clients and run dataworker function: ${Math.round(
           (dataworkerFunctionLoopTimerEnd - loopStart) / 1000
-        }s`,
-        timeToLoadSpokes: (dataworkerFunctionLoopTimerStart - loopStart) / 1000,
-        timeToRunDataworkerFunctions: (dataworkerFunctionLoopTimerEnd - dataworkerFunctionLoopTimerStart) / 1000,
+        )}s`,
+        timeToLoadSpokes: Math.round((dataworkerFunctionLoopTimerStart - loopStart) / 1000),
+        timeToRunDataworkerFunctions: Math.round(
+          (dataworkerFunctionLoopTimerEnd - dataworkerFunctionLoopTimerStart) / 1000
+        ),
       });
       loopStart = performance.now();
 

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -188,7 +188,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       logger.debug({
         at: "Dataworker#index",
         message: `Time to update spoke pool clients and run dataworker function: ${
-          (performance.now() - loopStart) / 1000
+          (dataworkerFunctionLoopTimerEnd - loopStart) / 1000
         }s`,
         timeToLoadSpokes: (dataworkerFunctionLoopTimerStart - loopStart) / 1000,
         timeToRunDataworkerFunctions: (dataworkerFunctionLoopTimerEnd - dataworkerFunctionLoopTimerStart) / 1000,

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -160,9 +160,11 @@ export async function finalize(
             client,
             l1ToL2AddressesToFinalize
           );
+
           callData.forEach((txn, idx) => {
             finalizationsToBatch.push({ txn, crossChainMessage: crossChainMessages[idx] });
           });
+
           totalWithdrawalsForChain += crossChainMessages.filter(({ type }) => type === "withdrawal").length;
           totalDepositsForChain += crossChainMessages.filter(({ type }) => type === "deposit").length;
           totalMiscTxnsForChain += crossChainMessages.filter(({ type }) => type === "misc").length;
@@ -414,7 +416,6 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Signer):
       } else {
         logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Finalizer disabled" });
       }
-
       const loopEndPostFinalizations = performance.now();
 
       logger.debug({

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -101,82 +101,75 @@ export async function finalize(
   const finalizationsToBatch: { txn: Multicall2Call; crossChainMessage?: CrossChainMessage }[] = [];
 
   // For each chain, delegate to a handler to look up any TokensBridged events and attempt finalization.
-  await Promise.all(
-    configuredChainIds.map(async (chainId) => {
-      const client = spokePoolClients[chainId];
-      if (client === undefined) {
+  await sdkUtils.mapAsync(configuredChainIds, async (chainId) => {
+    const client = spokePoolClients[chainId];
+    if (client === undefined) {
+      logger.warn({
+        at: "Finalizer",
+        message: `Skipping finalizations for ${getNetworkName(
+          chainId
+        )} because spoke pool client does not exist, is it disabled?`,
+        configuredChainIds,
+        availableChainIds: Object.keys(spokePoolClients),
+      });
+      return;
+    }
+
+    // We want to first resolve a possible override for the finalizer, and
+    // then fallback to the default finalizer.
+    const chainSpecificFinalizers = (chainFinalizerOverrides[chainId] ?? [chainFinalizers[chainId]]).filter(isDefined);
+    assert(chainSpecificFinalizers?.length > 0, `No finalizer available for chain ${chainId}`);
+
+    const network = getNetworkName(chainId);
+
+    // For certain chains we always want to track certain addresses for finalization:
+    // LineaL1ToL2: Always track HubPool, AtomicDepositor, LineaSpokePool. HubPool sends messages and tokens to the
+    // SpokePool, while the relayer rebalances ETH via the AtomicDepositor
+    if (chainId === hubChainId) {
+      if (chainId !== CHAIN_IDs.MAINNET) {
         logger.warn({
           at: "Finalizer",
-          message: `Skipping finalizations for ${getNetworkName(
-            chainId
-          )} because spoke pool client does not exist, is it disabled?`,
-          configuredChainIds,
-          availableChainIds: Object.keys(spokePoolClients),
+          message: "Testnet Finalizer: skipping finalizations where from or to address is set to AtomicDepositor",
         });
-        return;
       }
+      l1ToL2AddressesToFinalize = enrichL1ToL2AddressesToFinalize(l1ToL2AddressesToFinalize, [
+        hubPoolClient.hubPool.address,
+        spokePoolClients[hubChainId === CHAIN_IDs.MAINNET ? CHAIN_IDs.LINEA : CHAIN_IDs.LINEA_GOERLI].spokePool.address,
+        CONTRACT_ADDRESSES[hubChainId]?.atomicDepositor?.address,
+      ]);
+    }
 
-      // We want to first resolve a possible override for the finalizer, and
-      // then fallback to the default finalizer.
-      const chainSpecificFinalizers = (chainFinalizerOverrides[chainId] ?? [chainFinalizers[chainId]]).filter(
-        isDefined
+    // We can subloop through the finalizers for each chain, and then execute the finalizer. For now, the
+    // main reason for this is related to CCTP finalizations. We want to run the CCTP finalizer AND the
+    // normal finalizer for each chain. This is going to cause an overlap of finalization attempts on USDC.
+    // However, that's okay because each finalizer will only attempt to finalize the messages that it is
+    // responsible for.
+    let totalWithdrawalsForChain = 0;
+    let totalDepositsForChain = 0;
+    let totalMiscTxnsForChain = 0;
+    await sdkUtils.mapAsync(chainSpecificFinalizers, async (finalizer) => {
+      const { callData, crossChainMessages } = await finalizer(
+        logger,
+        hubSigner,
+        hubPoolClient,
+        client,
+        l1ToL2AddressesToFinalize
       );
-      assert(chainSpecificFinalizers?.length > 0, `No finalizer available for chain ${chainId}`);
 
-      const network = getNetworkName(chainId);
-
-      // For certain chains we always want to track certain addresses for finalization:
-      // LineaL1ToL2: Always track HubPool, AtomicDepositor, LineaSpokePool. HubPool sends messages and tokens to the
-      // SpokePool, while the relayer rebalances ETH via the AtomicDepositor
-      if (chainId === hubChainId) {
-        if (chainId !== CHAIN_IDs.MAINNET) {
-          logger.warn({
-            at: "Finalizer",
-            message: "Testnet Finalizer: skipping finalizations where from or to address is set to AtomicDepositor",
-          });
-        }
-        l1ToL2AddressesToFinalize = enrichL1ToL2AddressesToFinalize(l1ToL2AddressesToFinalize, [
-          hubPoolClient.hubPool.address,
-          spokePoolClients[hubChainId === CHAIN_IDs.MAINNET ? CHAIN_IDs.LINEA : CHAIN_IDs.LINEA_GOERLI].spokePool
-            .address,
-          CONTRACT_ADDRESSES[hubChainId]?.atomicDepositor?.address,
-        ]);
-      }
-
-      // We can subloop through the finalizers for each chain, and then execute the finalizer. For now, the
-      // main reason for this is related to CCTP finalizations. We want to run the CCTP finalizer AND the
-      // normal finalizer for each chain. This is going to cause an overlap of finalization attempts on USDC.
-      // However, that's okay because each finalizer will only attempt to finalize the messages that it is
-      // responsible for.
-      let totalWithdrawalsForChain = 0;
-      let totalDepositsForChain = 0;
-      let totalMiscTxnsForChain = 0;
-      await Promise.all(
-        chainSpecificFinalizers.map(async (finalizer) => {
-          const { callData, crossChainMessages } = await finalizer(
-            logger,
-            hubSigner,
-            hubPoolClient,
-            client,
-            l1ToL2AddressesToFinalize
-          );
-
-          callData.forEach((txn, idx) => {
-            finalizationsToBatch.push({ txn, crossChainMessage: crossChainMessages[idx] });
-          });
-
-          totalWithdrawalsForChain += crossChainMessages.filter(({ type }) => type === "withdrawal").length;
-          totalDepositsForChain += crossChainMessages.filter(({ type }) => type === "deposit").length;
-          totalMiscTxnsForChain += crossChainMessages.filter(({ type }) => type === "misc").length;
-        })
-      );
-      const totalTransfers = totalWithdrawalsForChain + totalDepositsForChain + totalMiscTxnsForChain;
-      logger.debug({
-        at: "finalize",
-        message: `Found ${totalTransfers} ${network} messages (${totalWithdrawalsForChain} withdrawals | ${totalDepositsForChain} deposits | ${totalMiscTxnsForChain} misc txns) for finalization.`,
+      callData.forEach((txn, idx) => {
+        finalizationsToBatch.push({ txn, crossChainMessage: crossChainMessages[idx] });
       });
-    })
-  );
+
+      totalWithdrawalsForChain += crossChainMessages.filter(({ type }) => type === "withdrawal").length;
+      totalDepositsForChain += crossChainMessages.filter(({ type }) => type === "deposit").length;
+      totalMiscTxnsForChain += crossChainMessages.filter(({ type }) => type === "misc").length;
+    });
+    const totalTransfers = totalWithdrawalsForChain + totalDepositsForChain + totalMiscTxnsForChain;
+    logger.debug({
+      at: "finalize",
+      message: `Found ${totalTransfers} ${network} messages (${totalWithdrawalsForChain} withdrawals | ${totalDepositsForChain} deposits | ${totalMiscTxnsForChain} misc txns) for finalization.`,
+    });
+  });
   const multicall2Lookup = Object.fromEntries(
     await Promise.all(
       uniq([

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -413,9 +413,9 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Signer):
 
       logger.debug({
         at: "Finalizer#index",
-        message: `Time to loop: ${(loopEndPostFinalizations - loopStart) / 1000}s`,
-        timeToUpdateSpokeClients: (loopStartPostSpokePoolUpdates - loopStart) / 1000,
-        timeToFinalize: (loopEndPostFinalizations - loopStartPostSpokePoolUpdates) / 1000,
+        message: `Time to loop: ${Math.round((loopEndPostFinalizations - loopStart) / 1000)}s`,
+        timeToUpdateSpokeClients: Math.round((loopStartPostSpokePoolUpdates - loopStart) / 1000),
+        timeToFinalize: Math.round((loopEndPostFinalizations - loopStartPostSpokePoolUpdates) / 1000),
       });
 
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) {


### PR DESCRIPTION
This PR aims to parallelize the finalizer code using `Promise.all( )`. Instrumentation that breaks down speed of spokes & finalizer/dataworker functions has also been added to capture improvements of this change. 

A draw of this PR is that it makes logs produced by the finalizer less linear.

Timings **prior** to optimization

```
2024-04-12 17:46:24 [debug]: {
  "at": "Finalizer#index",
  "message": "Time to loop: 85.80977033400535s",
  "timeToUpdateSpokeClients": 23.340696208953858,
  "timeToFinalize": 62.4690741250515,
  "bot-identifier": "not-james"
}

2024-04-12 17:49:17 [debug]: {
  "at": "Finalizer#index",
  "message": "Time to loop: 85.8968901669979s",
  "timeToUpdateSpokeClients": 23.311546999931334,
  "timeToFinalize": 62.585343167066576,
  "bot-identifier": "not-james"
}
```

Timings **post** optimization

```
2024-04-12 17:40:28 [debug]: {
  "at": "Finalizer#index",
  "message": "Time to loop: 67.65214512503147s",
  "timeToUpdateSpokeClients": 31.18309954202175,
  "timeToFinalize": 36.469045583009716,
  "bot-identifier": "not-james"
}

2024-04-12 17:51:23 [debug]: {
  "at": "Finalizer#index",
  "message": "Time to loop: 58.301649749994276s",
  "timeToUpdateSpokeClients": 24.055480499982835,
  "timeToFinalize": 34.24616925001144,
  "bot-identifier": "not-james"
}
```