### PR TITLE
feat(InventoryClient): Take repayment on chains that are over spoke target

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -313,3 +313,6 @@ export const TOKEN_APPROVALS_TO_FIRST_ZERO: Record<number, string[]> = {
 };
 
 export const DEFAULT_ARWEAVE_GATEWAY = { url: "arweave.net", port: 443, protocol: "https" };
+
+// Chains with slow (> 2 day liveness) canonical L2-->L1 bridges.
+export const SLOW_WITHDRAWAL_CHAINS = [CHAIN_IDs.BASE, CHAIN_IDs.ARBITRUM, CHAIN_IDs.OPTIMISM];

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -392,8 +392,8 @@ export async function _buildPoolRebalanceRoot(
   bundleSlowFillsV3: BundleSlowFills,
   unexecutableSlowFills: BundleExcessSlowFills,
   expiredDepositsToRefundV3: ExpiredDepositsToRefundV3,
-  clients: DataworkerClients,
-  maxL1TokenCountOverride: number | undefined
+  clients: Pick<DataworkerClients, "hubPoolClient" | "configStoreClient">,
+  maxL1TokenCountOverride?: number
 ): Promise<PoolRebalanceRoot> {
   // Running balances are the amount of tokens that we need to send to each SpokePool to pay for all instant and
   // slow relay refunds. They are decreased by the amount of funds already held by the SpokePool. Balances are keyed

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -115,7 +115,9 @@ describe("InventoryClient: Refund chain selection", async function () {
       hubPoolClient,
       bundleDataClient,
       adapterManager,
-      crossChainTransferClient
+      crossChainTransferClient,
+      false, // simMode
+      false // prioritizeUtilization
     );
 
     seedMocks(initialAllocation);
@@ -293,7 +295,9 @@ describe("InventoryClient: Refund chain selection", async function () {
         hubPoolClient,
         bundleDataClient,
         adapterManager,
-        crossChainTransferClient
+        crossChainTransferClient,
+        false, // simMode
+        false // prioritizeUtilization
       );
       expect(await _inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(
         sampleDepositData.destinationChainId


### PR DESCRIPTION
This algorithm is based on discussions with Korpi.

The current algorithm for determining refund chain is:
1. if destination relayer balance is under target, take repayment on destination
2. Else if origin relayer balance is under target, take repayment on origin
3. Else mainnet

The proposed changes to the algorithm add two new rules above 1:
1. Sort all 7day chains (i.e. ORU's with 7 day withdrawal liveness) by the amount that their "latest running balances" are over their `spokePoolTarget` and evaluate them in this order. Remove any chains where the excess is < 0.
2. For each of these chains, if the relayer balance is under allocated on this chain, take repayment there
3. If there are no more 7 day chains, then fallback to existing algorithm where we evaluate destination chain and then origin chain relayer balance allocation

The complexity of this PR is computing "latest running balances". The algorithm I'm using is:
- Find running balance for token and chain using latest proposed root bundle containing token and chain
- Add all deposited `inputAmounts` to running balances that occurred after the latest proposal's end block
- Subtract all refunds `inputAmounts` from running balances that occurred after the latest proposal's end block

The last bullet point is obviously risky since it opens the relayer up to being griefed and tricked into taking repayment on the chain if someone sends an invalid fill with a large `inputAmount` on a chain with cheap gas. This is pretty easy to do though I'm not sure why someone one would do it. The fix is a change to the algorithm in `getApproximateRefundsForBlockRange` to match fills and deposits on `inputAmount` and `outputAmount` in addition to originChain and depositId. It still allows invalid fills to be sent but its a good approximation for now
