### PR TITLE
fix(executor): Handle edge case when executing non-hub-chain pool leaves

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1706,12 +1706,11 @@ export class Dataworker {
 
         // @dev: Virtual balance = post-sync liquid reserves + any used balance.
         const multicallInput = [
-          hubPool.interface.encodeFunctionData("pooledTokens", [l1Token]),
           hubPool.interface.encodeFunctionData("sync", [l1Token]),
           hubPool.interface.encodeFunctionData("pooledTokens", [l1Token]),
         ];
         const multicallOutput = await hubPool.callStatic.multicall(multicallInput);
-        const updatedPooledTokens = hubPool.interface.decodeFunctionResult("pooledTokens", multicallOutput[2]);
+        const updatedPooledTokens = hubPool.interface.decodeFunctionResult("pooledTokens", multicallOutput[1]);
         const updatedLiquidReserves = updatedPooledTokens.liquidReserves;
         const virtualHubPoolBalance = updatedLiquidReserves.sub(
           balanceAllocator.getUsed(hubPoolChainId, l1Token, hubPool.address)

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -97,10 +97,10 @@ describe("Dataworker: Execute pool rebalances", async function () {
     await updateAllClients();
     await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
 
-    // Should be 3 transactions: 1 for the to chain, 1 for the from chain, and 1 for the extra ETH sent to cover
-    // arbitrum gas fees. exchangeRateCurrent isn't updated because liquidReserves wouldn't increase after calling
-    // sync() on the spoke pool.
-    expect(multiCallerClient.transactionCount()).to.equal(3);
+    // Should be 4 transactions: 1 for the to chain, 1 for the from chain, 1 for the extra ETH sent to cover
+    // arbitrum gas fees, and 1 to update the exchangeRate to execute the destination chain leaf.
+    // console.log(spy.getCall(-1))
+    expect(multiCallerClient.transactionCount()).to.equal(4);
     await multiCallerClient.executeTransactionQueue();
 
     // TEST 3:
@@ -268,7 +268,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
       it("exits early if passed in liquid reserves are greater than net send amount", async function () {
         const netSendAmount = toBNWei("1");
         const liquidReserves = toBNWei("2");
-        // For this test,pass in a liquid reserves object
+        // For this test, pass in a liquid reserves object
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
           {
             [l1Token_1.address]: liquidReserves,
@@ -285,6 +285,28 @@ describe("Dataworker: Execute pool rebalances", async function () {
         const liquidReserves = toBNWei("0");
         mockHubPoolClient.setLpTokenInfo(l1Token_1.address, 0, liquidReserves);
         balanceAllocator.addUsed(hubPoolClient.chainId, l1Token_1.address, hubPool.address, toBNWei(0));
+
+        // Even after simulating sync, there are not enough liquid reserves.
+        fakeHubPool.multicall.returns([
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            liquidReserves, // liquid reserves, set less than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+          ZERO_ADDRESS, // sync output
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            liquidReserves, // liquid reserves, >= than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+        ]);
+
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
           {},
           balanceAllocator,
@@ -296,16 +318,39 @@ describe("Dataworker: Execute pool rebalances", async function () {
         expect(updated.size).to.equal(0);
         expect(multiCallerClient.transactionCount()).to.equal(0);
       });
-      it("submits update: liquid reserves read from HubPoolClient", async function () {
-        const netSendAmount = toBNWei("1");
-
-        // Liquid reserves are read from HubPoolClient.
-        // Liquid reserves are below net send amount, but virtual balance is above net send amount.
-        const liquidReserves = toBNWei("0");
+      it("submits update: liquid reserves post-sync are enough to execute leaf", async function () {
+        const netSendAmount = toBNWei("10");
+        const liquidReserves = toBNWei("1");
         mockHubPoolClient.setLpTokenInfo(l1Token_1.address, 0, liquidReserves);
-        balanceAllocator.addUsed(1, l1Token_1.address, hubPool.address, netSendAmount.mul(-1));
+        balanceAllocator.addUsed(hubPoolClient.chainId, l1Token_1.address, hubPool.address, toBNWei(1));
+
+        // At this point, passed in liquid reserves will be 1 and the balance allocator will add 1.
+        // This won't be enough. However, we should test that the dataworker simulates sync-ing the exchange
+        // rate and sees that the liquid reserves post-sync are enough to execute the leaf.
+        fakeHubPool.multicall.returns([
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            liquidReserves, // liquid reserves, set less than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+          ZERO_ADDRESS, // sync output
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            netSendAmount, // liquid reserves, >= than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+        ]);
+
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
-          {},
+          {
+            [l1Token_1.address]: liquidReserves,
+          },
           balanceAllocator,
           [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
@@ -314,17 +359,35 @@ describe("Dataworker: Execute pool rebalances", async function () {
         expect(updated.has(l1Token_1.address)).to.be.true;
         expect(multiCallerClient.transactionCount()).to.equal(1);
       });
-      it("submits update: liquid reserves parameterized", async function () {
+      it("submits update: liquid reserves plus balanceAllocator.used are sufficient", async function () {
         const netSendAmount = toBNWei("1");
 
-        // Liquid reserves are passed as input.
+        // Liquid reserves are read from HubPoolClient.
         // Liquid reserves are below net send amount, but virtual balance is above net send amount.
         const liquidReserves = toBNWei("0");
+        mockHubPoolClient.setLpTokenInfo(l1Token_1.address, 0, liquidReserves);
         balanceAllocator.addUsed(1, l1Token_1.address, hubPool.address, netSendAmount.mul(-1));
+        fakeHubPool.multicall.returns([
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            liquidReserves, // liquid reserves, set less than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+          ZERO_ADDRESS, // sync output
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            liquidReserves, // liquid reserves, >= than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+        ]);
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
-          {
-            [l1Token_1.address]: liquidReserves,
-          },
+          {},
           balanceAllocator,
           [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
@@ -340,14 +403,33 @@ describe("Dataworker: Execute pool rebalances", async function () {
         // Liquid reserves are below net send amount, but virtual balance is above net send amount.
         const liquidReserves = toBNWei("0");
         balanceAllocator.addUsed(1, l1Token_1.address, hubPool.address, netSendAmount.mul(-1));
+        fakeHubPool.multicall.returns([
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            liquidReserves, // liquid reserves, set less than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+          ZERO_ADDRESS, // sync output
+          hubPool.interface.encodeFunctionResult("pooledTokens", [
+            ZERO_ADDRESS, // lp token address
+            true, // enabled
+            0, // last lp fee update
+            bnZero, // utilized reserves
+            netSendAmount, // liquid reserves, >= than netSendAmount
+            bnZero, // unaccumulated fees
+          ]),
+        ]);
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
           {
             [l1Token_1.address]: liquidReserves,
           },
           balanceAllocator,
           [
-            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 },
-            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 },
+            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 137 },
+            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 10 },
           ],
           true
         );

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -288,14 +288,6 @@ describe("Dataworker: Execute pool rebalances", async function () {
 
         // Even after simulating sync, there are not enough liquid reserves.
         fakeHubPool.multicall.returns([
-          hubPool.interface.encodeFunctionResult("pooledTokens", [
-            ZERO_ADDRESS, // lp token address
-            true, // enabled
-            0, // last lp fee update
-            bnZero, // utilized reserves
-            liquidReserves, // liquid reserves, set less than netSendAmount
-            bnZero, // unaccumulated fees
-          ]),
           ZERO_ADDRESS, // sync output
           hubPool.interface.encodeFunctionResult("pooledTokens", [
             ZERO_ADDRESS, // lp token address
@@ -328,14 +320,6 @@ describe("Dataworker: Execute pool rebalances", async function () {
         // This won't be enough. However, we should test that the dataworker simulates sync-ing the exchange
         // rate and sees that the liquid reserves post-sync are enough to execute the leaf.
         fakeHubPool.multicall.returns([
-          hubPool.interface.encodeFunctionResult("pooledTokens", [
-            ZERO_ADDRESS, // lp token address
-            true, // enabled
-            0, // last lp fee update
-            bnZero, // utilized reserves
-            liquidReserves, // liquid reserves, set less than netSendAmount
-            bnZero, // unaccumulated fees
-          ]),
           ZERO_ADDRESS, // sync output
           hubPool.interface.encodeFunctionResult("pooledTokens", [
             ZERO_ADDRESS, // lp token address
@@ -368,14 +352,6 @@ describe("Dataworker: Execute pool rebalances", async function () {
         mockHubPoolClient.setLpTokenInfo(l1Token_1.address, 0, liquidReserves);
         balanceAllocator.addUsed(1, l1Token_1.address, hubPool.address, netSendAmount.mul(-1));
         fakeHubPool.multicall.returns([
-          hubPool.interface.encodeFunctionResult("pooledTokens", [
-            ZERO_ADDRESS, // lp token address
-            true, // enabled
-            0, // last lp fee update
-            bnZero, // utilized reserves
-            liquidReserves, // liquid reserves, set less than netSendAmount
-            bnZero, // unaccumulated fees
-          ]),
           ZERO_ADDRESS, // sync output
           hubPool.interface.encodeFunctionResult("pooledTokens", [
             ZERO_ADDRESS, // lp token address
@@ -404,14 +380,6 @@ describe("Dataworker: Execute pool rebalances", async function () {
         const liquidReserves = toBNWei("0");
         balanceAllocator.addUsed(1, l1Token_1.address, hubPool.address, netSendAmount.mul(-1));
         fakeHubPool.multicall.returns([
-          hubPool.interface.encodeFunctionResult("pooledTokens", [
-            ZERO_ADDRESS, // lp token address
-            true, // enabled
-            0, // last lp fee update
-            bnZero, // utilized reserves
-            liquidReserves, // liquid reserves, set less than netSendAmount
-            bnZero, // unaccumulated fees
-          ]),
           ZERO_ADDRESS, // sync output
           hubPool.interface.encodeFunctionResult("pooledTokens", [
             ZERO_ADDRESS, // lp token address


### PR DESCRIPTION
There is one missing case not handled:
- HubChain Leaf for a token has a negative net send amount, so no exchange rate needed
- RelayerLeaf for token has a positive amount to return. This adds virtual balance for the token
- non-HubChain leaf for the token has a positive net send amount. The `liquidReserves + amountToReturn` is still `< netSendAmount`. This throws an error. However, we should be checking if calling `exchangeRateCurrent` on the `liquidReserves` sends liquid reserves above the required amount. This follows the pattern in the other two exchange rate update cases
