### PR TITLE
improve(adapters): make adapter more dynamic

### DIFF
--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -229,14 +229,18 @@ export class ArbitrumAdapter extends BaseAdapter {
   }
 
   getL1Bridge(l1Token: SupportedL1Token): Contract {
-    return new Contract(l1Gateways[l1Token], CONTRACT_ADDRESSES[1].arbitrumErc20GatewayRouter.abi, this.getSigner(1));
+    return new Contract(
+      l1Gateways[l1Token],
+      CONTRACT_ADDRESSES[1].arbitrumErc20GatewayRouter.abi,
+      this.getSigner(this.hubChainId)
+    );
   }
 
   getL1GatewayRouter(): Contract {
     return new Contract(
       CONTRACT_ADDRESSES[1].arbitrumErc20GatewayRouter.address,
       CONTRACT_ADDRESSES[1].arbitrumErc20GatewayRouter.abi,
-      this.getSigner(1)
+      this.getSigner(this.hubChainId)
     );
   }
 

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -262,7 +262,7 @@ export class PolygonAdapter extends BaseAdapter {
     return new Contract(
       tokenToBridge[l1Token].l1BridgeAddress,
       CONTRACT_ADDRESSES[1].polygonBridge.abi,
-      this.getSigner(1)
+      this.getSigner(this.hubChainId)
     );
   }
 
@@ -273,7 +273,7 @@ export class PolygonAdapter extends BaseAdapter {
       return new Contract(
         CONTRACT_ADDRESSES[1].polygonRootChainManager.address,
         CONTRACT_ADDRESSES[1].polygonRootChainManager.abi,
-        this.getSigner(1)
+        this.getSigner(this.hubChainId)
       );
     }
   }

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -14,6 +14,7 @@ import {
   paginatedEventQuery,
   CHAIN_IDs,
   TOKEN_SYMBOLS_MAP,
+  bnZero,
 } from "../../utils";
 import { SpokePoolClient } from "../../clients";
 import { BaseAdapter } from "./";
@@ -238,7 +239,7 @@ export class PolygonAdapter extends BaseAdapter {
       method,
       args,
       1,
-      BigNumber.from(0),
+      bnZero,
       simMode
     );
   }

--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -11,6 +11,7 @@ import {
   ZERO_ADDRESS,
   getTokenAddress,
   TOKEN_SYMBOLS_MAP,
+  bnZero,
 } from "../../utils";
 import { SpokePoolClient } from "../.";
 import assert from "assert";
@@ -176,7 +177,7 @@ export class ZKSyncAdapter extends BaseAdapter {
       address, // Refund recipient. Can set to caller address if an EOA.
     ];
     let method = "bridgeWethToZkSync";
-    let value = BigNumber.from(0);
+    let value = bnZero;
 
     // If not using AtomicDepositor with WETH, sending over default ERC20 bridge requires including enough
     // msg.value to cover the L2 transaction cost.


### PR DESCRIPTION
We should use the more dynamic `this.hubChainId` and `bnZero` instead of hardcoding 1 & BigNumber.from(0)