### PR TITLE
feat(Dataworker#index): Catch PoolRebalanceLeaf execution collisions

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -175,8 +175,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         const pendingProposal = await clients.hubPoolClient.hubPool.rootBundleProposal();
         const proposalCollision =
           isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== "0";
-        const executorCollision = 
-  pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
+        const executorCollision =
+        pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
         if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -176,7 +176,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         const proposalCollision =
           isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== "0";
         const executorCollision =
-        pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
+          pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
         if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -176,7 +176,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         const proposalCollision =
           isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== "0";
         const executorCollision =
-          pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
+          pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount.toString();
         if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -175,7 +175,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         const pendingProposal = await clients.hubPoolClient.hubPool.rootBundleProposal();
         const proposalCollision =
           isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== "0";
-        const executorCollision = pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
+        const executorCollision = 
+pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
         if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -176,7 +176,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         const proposalCollision =
           isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== "0";
         const executorCollision = 
-pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
+  pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== poolRebalanceLeafExecutionCount;
         if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -62,6 +62,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
   });
   loopStart = performance.now();
   let bundleDataToPersist: BundleDataToPersistToDALayerType | undefined = undefined;
+  let poolRebalanceLeafExecutionCount = 0;
   try {
     logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
 
@@ -129,7 +130,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       if (config.executorEnabled) {
         const balanceAllocator = new BalanceAllocator(spokePoolClientsToProviders(spokePoolClients));
 
-        await dataworker.executePoolRebalanceLeaves(
+        poolRebalanceLeafExecutionCount = await dataworker.executePoolRebalanceLeaves(
           spokePoolClients,
           balanceAllocator,
           config.sendingExecutionsEnabled,
@@ -167,14 +168,28 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         }
       };
 
-      // The dataworker loop takes a long-time to run, so if the proposer is enabled, run a final check and early
-      // exit if a proposal is already pending.
-      const executeProposal = async () => {
+      // @dev The dataworker loop takes a long-time to run, so if the proposer is enabled, run a final check and early
+      // exit if a proposal is already pending. Similarly, the executor is enabled and if there are pool rebalance
+      // leaves to be executed but the proposed bundle was already executed, then exit early.
+      // @dev This assumes that this bot is running in a serverless setting
+      // and that there is the possibility of overlapping runs that could cause one run to "front-run" a previous
+      // bot instance.
+      const executeDataworkerTransactions = async () => {
         const pendingProposal = await clients.hubPoolClient.hubPool.rootBundleProposal();
-        if (isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== "0") {
+        const proposalCollision =
+          isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() !== "0";
+        // This assumes that all pool leaves get executed together in a single transaction. This should
+        // always be the case, which means that the unclaimed leaf count is always in either exactly two states:
+        // equal to the maximum unclaimed leaf count or 0.
+        const executorCollision =
+          poolRebalanceLeafExecutionCount > 0 && pendingProposal.unclaimedPoolRebalanceLeafCount.toString() === "0";
+        if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",
-            message: "Exiting early as a proposal is already pending",
+            message: "Exiting early due to dataworker function collision",
+            proposalCollision,
+            executorCollision,
+            pendingProposal,
           });
         } else {
           await clients.multiCallerClient.executeTransactionQueue();
@@ -183,7 +198,10 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
 
       // We want to persist the bundle data to the DALayer *AND* execute the multiCall transaction queue
       // in parallel. We want to have both of these operations complete, even if one of them fails.
-      const [persistResult, multiCallResult] = await Promise.allSettled([persistBundle(), executeProposal()]);
+      const [persistResult, multiCallResult] = await Promise.allSettled([
+        persistBundle(),
+        executeDataworkerTransactions(),
+      ]);
 
       // If either of the operations failed, log the error.
       if (persistResult.status === "rejected" || multiCallResult.status === "rejected") {

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -95,7 +95,11 @@ describe("Dataworker: Execute pool rebalances", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
+    let leafCount = await dataworkerInstance.executePoolRebalanceLeaves(
+      spokePoolClients,
+      new BalanceAllocator(providers)
+    );
+    expect(leafCount).to.equal(2);
 
     // Should be 4 transactions: 1 for the to chain, 1 for the from chain, 1 for the extra ETH sent to cover
     // arbitrum gas fees, and 1 to update the exchangeRate to execute the destination chain leaf.
@@ -114,7 +118,8 @@ describe("Dataworker: Execute pool rebalances", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
+    leafCount = await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
+    expect(leafCount).to.equal(0);
     expect(multiCallerClient.transactionCount()).to.equal(0);
   });
   describe("update exchange rates", function () {


### PR DESCRIPTION
`executePoolRebalanceLeaves` sends `.error` level logs if it tries to execute pool rebalance leaves but gets front-run. SpokeLeaf execution failures do not send `.error` level logs because I believe they are allowed to fail in simulation (except HubChain leaves which get batched with pool leaf executions).

This PR adds a return value to `executePoolRebalanceLeaves` so the index.ts runner can know if any pool leaf executions have been enqueued. If any have been, then run a similar check to https://github.com/across-protocol/relayer-v3/pull/1425 and exit early if the root bundle has already been executed