### PR TITLE
improve: Allow BalanceAllocator users to force balance refresh

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1179,7 +1179,9 @@ export class Dataworker {
             destinationChainId,
             l2TokensToCountTowardsSpokePoolLeafExecutionCapital(outputToken, destinationChainId),
             client.spokePool.address,
-            amountRequired
+            amountRequired,
+            true // refreshBalances set to true. The dataworker takes a long time to run and balances can change
+            // in the  middle of the run, therefore we should force refresh the balances
           );
 
           if (!success) {
@@ -1500,7 +1502,9 @@ export class Dataworker {
           }
 
           const success = await balanceAllocator.requestBalanceAllocations(
-            requests.filter((req) => req.amount.gt(bnZero))
+            requests.filter((req) => req.amount.gt(bnZero)),
+            true // refreshBalances is set to true because dataworker functions take a long time to run and
+            // balances can change in the middle of the run, so we force refresh.
           );
 
           if (!success) {
@@ -2041,7 +2045,11 @@ export class Dataworker {
           }
           // We use the requestBalanceAllocations instead of two separate calls to requestBalanceAllocation because
           // we want the balance to be set in an atomic transaction.
-          const success = await balanceAllocator.requestBalanceAllocations(balanceRequestsToQuery);
+          const success = await balanceAllocator.requestBalanceAllocations(
+            balanceRequestsToQuery,
+            true // refreshBalances is set to true because dataworker functions take a long time to run and
+            // balances can change in the middle of the run, so we force refresh.
+          );
           if (!success) {
             this.logger.warn({
               at: "Dataworker#executeRelayerRefundLeaves",

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -411,7 +411,8 @@ export class Monitor {
             chainId,
             [token],
             signerAddress,
-            deficit
+            deficit,
+            true // refreshBalances force refreshes on-chain balances.
           );
           if (canRefill) {
             this.logger.debug({


### PR DESCRIPTION
Users of the balance allocator (the Dataworker and the Monitor) use this client to track balance in order to decide when to proceed with an action. The issue is the rest of the bot's logic takes a while to run causing the balances fetched to become several minutes stale by the time the logic is acted upon.

I think the "force refresh" optional param is generally a useful feature and the places where I force refreshes:
- relayer refund leaf executor
- pool rebalance leaf executor
- slow fill leaf executor
- monitor refill balances from relayer address to dataworker address
