### PR TITLE
fix(test): Prevent Redis from being used in test

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint-fix": "yarn eslint --fix && yarn prettier --write",
     "prettier": "prettier .",
     "eslint": "eslint .",
-    "test": "hardhat test",
+    "test": "RELAYER_TEST=true hardhat test",
     "build": "tsc --build",
     "watch": "tsc --build --incremental --watch",
     "build:test": "tsc --project tsconfig.test.json",

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -102,6 +102,11 @@ export async function getRedisCache(
   logger?: winston.Logger,
   url?: string
 ): Promise<CachingMechanismInterface | undefined> {
+  // Don't permit redis to be used in test.
+  if (isDefined(process.env.RELAYER_TEST)) {
+    return undefined;
+  }
+
   const client = await getRedis(logger, url);
   if (client) {
     return new RedisCache(client);


### PR DESCRIPTION
Redis has unintentionally been used in the TokenClient tests when tested in a local development environment. It hasn't affected CI because there's no redis cache available there.