### PR TITLE
fix(AcrossAPIClient): Reverse limits query direction

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -64,7 +64,7 @@ export class AcrossApiClient {
 
     // /limits
     // Store the max deposit limit for each L1 token. The origin chain can be any supported chain
-    // expect the HubPool chain. This assumes the worst-case bridging delay of SpokePool -> mainnet.
+    // expect the HubPool chain. This assumes the worst-case bridging delay of !mainnet -> mainnet.
     const data = await Promise.all(
       tokensQuery.map((l1Token) => {
         const l2TokenAddresses = getL2TokenAddresses(l1Token);

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import axios, { AxiosError } from "axios";
-import { SpokePoolClientsByChain } from "../interfaces";
 import {
   bnZero,
   isDefined,
@@ -10,6 +9,7 @@ import {
   CHAIN_IDs,
   TOKEN_SYMBOLS_MAP,
   getRedisCache,
+  bnUint256Max as uint256Max,
 } from "../utils";
 import { HubPoolClient } from "./HubPoolClient";
 
@@ -19,7 +19,7 @@ export interface DepositLimits {
 
 export class AcrossApiClient {
   private endpoint = "https://app.across.to/api";
-
+  private chainIds: number[];
   private limits: { [token: string]: BigNumber } = {};
 
   public updatedLimits = false;
@@ -28,17 +28,19 @@ export class AcrossApiClient {
   constructor(
     readonly logger: winston.Logger,
     readonly hubPoolClient: HubPoolClient,
-    readonly spokePoolClients: SpokePoolClientsByChain,
+    chainIds: number[],
     readonly tokensQuery: string[] = [],
     readonly timeout: number = 3000
   ) {
     if (Object.keys(tokensQuery).length === 0) {
-      this.tokensQuery = Object.entries(TOKEN_SYMBOLS_MAP).map(([, details]) => details.addresses[CHAIN_IDs.MAINNET]);
+      this.tokensQuery = Object.values(TOKEN_SYMBOLS_MAP).map(({ addresses }) => addresses[CHAIN_IDs.MAINNET]);
     }
+
+    this.chainIds = chainIds.filter((chainId) => chainId !== hubPoolClient.chainId);
   }
 
   async update(ignoreLimits: boolean): Promise<void> {
-    if (ignoreLimits) {
+    if (ignoreLimits || this.chainIds.length === 0) {
       this.logger.debug({ at: "AcrossAPIClient", message: "Skipping querying /limits" });
       return;
     }
@@ -61,37 +63,29 @@ export class AcrossApiClient {
     this.updatedLimits = false;
 
     // /limits
-    // - Store the max deposit limit for each L1 token. DestinationChainId doesn't matter since HubPool
-    // liquidity is shared for all tokens and affects maxDeposit. We don't care about maxDepositInstant
-    // when deciding whether a relay will be refunded.
-    const mainnetSpokePoolClient = this.spokePoolClients[hubPoolClient.chainId];
-    if (!mainnetSpokePoolClient.isUpdated) {
-      throw new Error("Mainnet SpokePoolClient for chainId must be updated before AcrossAPIClient");
-    }
-
+    // Store the max deposit limit for each L1 token. The origin chain can be any supported chain
+    // expect the HubPool chain. This assumes the worst-case bridging delay of SpokePool -> mainnet.
     const data = await Promise.all(
       tokensQuery.map((l1Token) => {
         const l2TokenAddresses = getL2TokenAddresses(l1Token);
-        const destinationChains = Object.keys(l2TokenAddresses)
+        const originChainIds = Object.keys(l2TokenAddresses)
           .map((chainId) => Number(chainId))
           .filter((chainId) => {
             try {
-              // Verify that a token mapping exists on the destination chain.
+              // Verify that a token mapping exists on the origin chain.
               hubPoolClient.getL2TokenForL1TokenAtBlock(l1Token, chainId); // throws if not found.
-              return (
-                chainId !== hubPoolClient.chainId && Object.keys(this.spokePoolClients).includes(chainId.toString())
-              );
+              return this.chainIds.includes(chainId);
             } catch {
               return false;
             }
           });
 
         // No valid deposit routes from mainnet for this token. We won't record a limit for it.
-        if (destinationChains.length === 0) {
+        if (originChainIds.length === 0) {
           return undefined;
         }
 
-        return this.callLimits(l1Token, destinationChains);
+        return this.callLimits(l1Token, originChainIds);
       })
     );
 
@@ -116,7 +110,12 @@ export class AcrossApiClient {
     this.updatedLimits = true;
   }
 
-  getLimit(l1Token: string): BigNumber {
+  getLimit(originChainId: number, l1Token: string): BigNumber {
+    // Funds can be bridged from mainnet to anywhere, so don't apply any constraint.
+    if (originChainId === this.hubPoolClient.chainId) {
+      return uint256Max;
+    }
+
     if (!this.limits[l1Token]) {
       this.logger.warn({
         at: "AcrossApiClient::getLimit",
@@ -127,24 +126,24 @@ export class AcrossApiClient {
     return this.limits[l1Token];
   }
 
-  getLimitsCacheKey(l1Token: string, destinationChainId: number): string {
-    return `limits_api_${l1Token}_${destinationChainId}`;
+  getLimitsCacheKey(l1Token: string, originChainId: number): string {
+    return `limits_api_${l1Token}_${originChainId}`;
   }
 
-  private async callLimits(
-    l1Token: string,
-    destinationChainIds: number[],
-    timeout = this.timeout
-  ): Promise<DepositLimits> {
+  private async callLimits(l1Token: string, originChainIds: number[], timeout = this.timeout): Promise<DepositLimits> {
     const path = "limits";
     const url = `${this.endpoint}/${path}`;
 
     const redis = await getRedisCache();
-    for (const destinationChainId of destinationChainIds) {
-      const params = { token: l1Token, destinationChainId, originChainId: 1 };
+
+    // Assume worst-case payout on mainnet.
+    const destinationChainId = this.hubPoolClient.chainId;
+    for (const originChainId of originChainIds) {
+      const token = this.hubPoolClient.getL2TokenForL1TokenAtBlock(l1Token, originChainId);
+      const params = { token, originChainId, destinationChainId };
       if (redis) {
         try {
-          const cachedLimits = await redis.get<string>(this.getLimitsCacheKey(l1Token, destinationChainId));
+          const cachedLimits = await redis.get<string>(this.getLimitsCacheKey(l1Token, originChainId));
           if (cachedLimits !== null) {
             return { maxDeposit: BigNumber.from(cachedLimits) };
           }
@@ -153,7 +152,7 @@ export class AcrossApiClient {
             at: "AcrossAPIClient",
             message: "Failed to get cached limits data",
             l1Token,
-            destinationChainId,
+            originChainId,
             error: e,
           });
         }
@@ -175,7 +174,7 @@ export class AcrossApiClient {
           const baseTtl = 300;
           // Apply a random margin to spread expiry over a larger time window.
           const ttl = baseTtl + Math.ceil(_.random(-0.5, 0.5, true) * baseTtl);
-          await redis.set(this.getLimitsCacheKey(l1Token, destinationChainId), result.data.maxDeposit.toString(), ttl);
+          await redis.set(this.getLimitsCacheKey(l1Token, originChainId), result.data.maxDeposit.toString(), ttl);
         }
         return result.data;
       } catch (err) {

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -40,6 +40,7 @@ export class AcrossApiClient {
   }
 
   async update(ignoreLimits: boolean): Promise<void> {
+    // If no chainIds are specified, the origin chain is assumed to be the HubPool chain, so skip update.
     if (ignoreLimits || this.chainIds.length === 0) {
       this.logger.debug({ at: "AcrossAPIClient", message: "Skipping querying /limits" });
       return;

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -69,7 +69,7 @@ export class AcrossApiClient {
       tokensQuery.map((l1Token) => {
         const l2TokenAddresses = getL2TokenAddresses(l1Token);
         const originChainIds = Object.keys(l2TokenAddresses)
-          .map((chainId) => Number(chainId))
+          .map(Number)
           .filter((chainId) => {
             try {
               // Verify that a token mapping exists on the origin chain.

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -111,7 +111,7 @@ export class AcrossApiClient {
   }
 
   getLimit(originChainId: number, l1Token: string): BigNumber {
-    // Funds can be bridged from mainnet to anywhere, so don't apply any constraint.
+    // Funds can be JIT-bridged from mainnet to anywhere, so don't apply any constraint.
     if (originChainId === this.hubPoolClient.chainId) {
       return uint256Max;
     }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -147,16 +147,17 @@ export class Relayer {
       return false;
     }
 
-    // We query the relayer API to get the deposit limits for different token and destination combinations.
+    // We query the relayer API to get the deposit limits for different token and origin combinations.
     // The relayer should *not* be filling deposits that the HubPool doesn't have liquidity for otherwise the relayer's
     // refund will be stuck for potentially 7 days. Note: Filter for supported tokens first, since the relayer only
     // queries for limits on supported tokens.
     const { inputAmount } = deposit;
-    if (acrossApiClient.updatedLimits && inputAmount.gt(acrossApiClient.getLimit(l1Token.address))) {
+    const limit = acrossApiClient.getLimit(originChainId, l1Token.address);
+    if (acrossApiClient.updatedLimits && inputAmount.gt(limit)) {
       this.logger.warn({
         at: "Relayer::filterDeposit",
         message: "😱 Skipping deposit with greater unfilled amount than API suggested limit",
-        limit: acrossApiClient.getLimit(l1Token.address),
+        limit,
         l1Token: l1Token.address,
         depositId,
         inputToken,

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -119,18 +119,13 @@ export async function constructRelayerClients(
     );
   }
 
-  // We only use the API client to load /limits for chains so we should remove any chains that are not included in the
-  // destination chain list.
-  const destinationSpokePoolClients =
-    config.relayerDestinationChains.length === 0
-      ? spokePoolClients
-      : Object.fromEntries(
-          Object.keys(spokePoolClients)
-            .filter((chainId) => config.relayerDestinationChains.includes(Number(chainId)))
-            .map((chainId) => [chainId, spokePoolClients[chainId]])
-        );
+  // Determine which origin chains to query limits for.
+  const srcChainIds =
+    config.relayerOriginChains.length > 0
+      ? config.relayerOriginChains
+      : Object.values(spokePoolClients).map(({ chainId }) => chainId);
+  const acrossApiClient = new AcrossApiClient(logger, hubPoolClient, srcChainIds, config.relayerTokens);
 
-  const acrossApiClient = new AcrossApiClient(logger, hubPoolClient, destinationSpokePoolClients, config.relayerTokens);
   const tokenClient = new TokenClient(logger, signerAddr, spokePoolClients, hubPoolClient);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -55,6 +55,8 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
   let multiCallerClient: MultiCallerClient, profitClient: MockProfitClient;
   let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
+  let chainIds: number[];
+
   const updateAllClients = async (): Promise<void> => {
     await configStoreClient.update();
     await hubPoolClient.update();
@@ -137,6 +139,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       await profitClient.initToken(erc20);
     }
 
+    chainIds = Object.values(spokePoolClients).map(({ chainId }) => chainId);
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,
@@ -148,7 +151,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(null, null, null, null, null, hubPoolClient),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, chainIds),
       },
       {
         relayerTokens: [],
@@ -279,7 +282,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
           profitClient,
           multiCallerClient,
           inventoryClient: new MockInventoryClient(),
-          acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
+          acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, chainIds),
         },
         {
           relayerTokens: [],
@@ -399,7 +402,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
           profitClient,
           multiCallerClient,
           inventoryClient: new MockInventoryClient(null, null, null, null, null, hubPoolClient),
-          acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
+          acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, chainIds),
         },
         {
           relayerTokens: [],

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -140,6 +140,8 @@ describe("Relayer: Initiates slow fill requests", async function () {
       null,
       mockCrossChainTransferClient
     );
+
+    const chainIds = Object.values(spokePoolClients).map(({ chainId }) => chainId);
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,
@@ -151,7 +153,7 @@ describe("Relayer: Initiates slow fill requests", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: mockInventoryClient,
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, chainIds),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -133,6 +133,7 @@ describe("Relayer: Token balance shortfall", async function () {
       await profitClient.initToken(erc20);
     }
 
+    const chainIds = Object.values(spokePoolClients).map(({ chainId }) => chainId);
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,
@@ -154,7 +155,7 @@ describe("Relayer: Token balance shortfall", async function () {
           null,
           new MockCrossChainTransferClient()
         ),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, chainIds),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -115,6 +115,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
     await profitClient.initToken(l1Token);
 
+    const chainIds = Object.values(spokePoolClients).map(({ chainId }) => chainId);
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,
@@ -126,7 +127,7 @@ describe("Relayer: Unfilled Deposits", async function () {
         tokenClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(null, null, null, null, null, hubPoolClient),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, chainIds),
       },
       {
         relayerTokens: [],


### PR DESCRIPTION
When querying limits, the API client current uses mainnet as the origin chain. The buffers applied on deposits originating from mainnet are typically negative, implying that Across can support _more_ volume than is available as liquid reserve in the HubPool. This effectively renders the limits check redundant and could cause the relayer to overcommit the HubPool by incorrectly making a fill.

While here, apply a slight refactor in recognition that API client doesn't need require SpokePoolClient instances anymore, so drop them in favour of a simple chain ID list. This removes the current constraint that mainnet needs to be defined as a destination chain. This adjustment makes the relayer more flexible and should be popular with third-parties.

Fixes ACX-2100