### PR TITLE
improve(Dataworker#index): Handle executor run not completing before subsequent proposal is sent

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -180,9 +180,13 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
 
       const executeDataworkerTransactions = async () => {
         const proposalCollision = isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount > 0;
+        // The pending root bundle that we want to execute has already been executed if its unclaimed leaf count
+        // is greater than 0 or its challenge period timestamp is in the future. This latter case is rarer but it can
+        // happen if a proposal in addition to the root bundle execution happens in the middle of this executor run.
         const executorCollision =
           poolRebalanceLeafExecutionCount > 0 &&
-          pendingProposal.unclaimedPoolRebalanceLeafCount !== poolRebalanceLeafExecutionCount;
+          pendingProposal.unclaimedPoolRebalanceLeafCount !== poolRebalanceLeafExecutionCount &&
+          pendingProposal.challengePeriodEndTimestamp > Date.now();
         if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -181,12 +181,13 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
       const executeDataworkerTransactions = async () => {
         const proposalCollision = isDefined(bundleDataToPersist) && pendingProposal.unclaimedPoolRebalanceLeafCount > 0;
         // The pending root bundle that we want to execute has already been executed if its unclaimed leaf count
-        // is greater than 0 or its challenge period timestamp is in the future. This latter case is rarer but it can
+        // does not match the number of leaves the executor wants to execute, or the pending root bundle's
+        // challenge period timestamp is in the future. This latter case is rarer but it can
         // happen if a proposal in addition to the root bundle execution happens in the middle of this executor run.
         const executorCollision =
           poolRebalanceLeafExecutionCount > 0 &&
-          pendingProposal.unclaimedPoolRebalanceLeafCount !== poolRebalanceLeafExecutionCount &&
-          pendingProposal.challengePeriodEndTimestamp > Date.now();
+          (pendingProposal.unclaimedPoolRebalanceLeafCount !== poolRebalanceLeafExecutionCount ||
+            pendingProposal.challengePeriodEndTimestamp > clients.hubPoolClient.currentTime);
         if (proposalCollision || executorCollision) {
           logger[startupLogLevel(config)]({
             at: "Dataworker#index",


### PR DESCRIPTION
When the executor runs very slowly, say ~10 mins, then its possible that its run can start while a root bundle proposal is still pending, but in the middle of its run, the pending root bundle can be executed and the next bundle can be proposed.

The proposal would cause the current logic for detecting an `executorCollision` to give a false negative, resulting in an error suffered in the MulticallerClient.

This PR adds a check to `executorCollision` that the pending root bundle challenge timestamp is in the future in addition to its unclaimedLeafCount being positive.

An alternative implementation I considered was comparing the pending root bundle's `poolRebalanceRoot` with the one stored in the `HubPoolClient`. I think that would work as well.
