### PR TITLE
improve(MulticallerClient): Don't log sim failures as "error" level if simulate=true

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -206,7 +206,9 @@ export class MultiCallerClient {
     const batchSimResults = await this.txnClient.simulate(batchTxns);
     const batchesAllSucceeded = batchSimResults.every(({ succeed, transaction, reason }, idx) => {
       // If txn succeeded or the revert reason is known to be benign, then log at debug level.
-      this.logger[succeed || this.canIgnoreRevertReason({ succeed, transaction, reason }) ? "debug" : "error"]({
+      this.logger[
+        succeed || simulate || this.canIgnoreRevertReason({ succeed, transaction, reason }) ? "debug" : "error"
+      ]({
         at: "MultiCallerClient#executeChainTxnQueue",
         message: `${succeed ? "Successfully simulated" : "Failed to simulate"} ${networkName} transaction batch!`,
         batchTxn: { ...transaction, contract: transaction.contract.address },


### PR DESCRIPTION
We don't want to pollute relayer logging channels that are not sending relays. For example, the rebalancer runs the full relayer run in order to get an accurate count of its inventory but it shouldn't care about whether the relays succeed or not in simulation.