### PR TITLE
improve(relayer): Skip querying EnabledDepositRoute events

### DIFF
--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -98,7 +98,6 @@ export async function constructSpokePoolClientsForFastDataworker(
     endBlocks
   );
   await updateSpokePoolClients(spokePoolClients, [
-    "EnabledDepositRoute",
     "RelayedRootBundle",
     "ExecutedRelayerRefundRoot",
     "V3FundsDeposited",

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -386,7 +386,7 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Signer):
   try {
     for (;;) {
       const loopStart = performance.now();
-      await updateSpokePoolClients(spokePoolClients, ["TokensBridged", "EnabledDepositRoute"]);
+      await updateSpokePoolClients(spokePoolClients, ["TokensBridged"]);
       const loopStartPostSpokePoolUpdates = performance.now();
 
       if (config.finalizerEnabled) {

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -81,7 +81,6 @@ export async function constructMonitorClients(
 
 export async function updateMonitorClients(clients: MonitorClients): Promise<void> {
   await updateSpokePoolClients(clients.spokePoolClients, [
-    "EnabledDepositRoute",
     "RelayedRootBundle",
     "ExecutedRelayerRefundRoot",
     "V3FundsDeposited",

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -207,7 +207,6 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
     "V3FundsDeposited",
     "RequestedSpeedUpV3Deposit",
     "FilledV3Relay",
-    "EnabledDepositRoute",
     "RelayedRootBundle",
     "ExecutedRelayerRefundRoot",
   ]);

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -445,7 +445,6 @@ export async function runScript(_logger: winston.Logger, baseSigner: Signer): Pr
         spokeClientToBlocks
       );
       await updateSpokePoolClients(spokePoolClientsForBundle, [
-        "EnabledDepositRoute",
         "RelayedRootBundle",
         "ExecutedRelayerRefundRoot",
         "V3FundsDeposited",


### PR DESCRIPTION
These are no longer necessary for the relayer. This change has already been implemented in the fast relayer.

This event is by far the most request-intensive in the relayer, so I'm hopeful of a nice speed-up once it goes into prod.