### PR TITLE
refactor(InventoryClient): Simplify possible rebalances check

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -610,7 +610,7 @@ export class InventoryClient {
     const rebalancesRequired: Rebalance[] = [];
 
     // First, compute the rebalances that we would do assuming we have sufficient tokens on L1.
-    for (const l1Token of Object.keys(this.getL1Tokens())) {
+    for (const l1Token of this.getL1Tokens()) {
       const cumulativeBalance = this.getCumulativeBalance(l1Token);
       if (cumulativeBalance.eq(bnZero)) {
         continue;

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -627,7 +627,6 @@ export class InventoryClient {
         const { thresholdPct, targetPct } = this.inventoryConfig.tokenConfig[l1Token][chainId];
         if (currentAllocPct.lt(thresholdPct)) {
           const deltaPct = targetPct.sub(currentAllocPct);
-          // Divide by scalar because allocation percent was multiplied by it to avoid rounding errors.
           const amount = deltaPct.mul(cumulativeBalance).div(this.scalar);
           const balance = this.tokenClient.getBalance(this.hubPoolClient.chainId, l1Token);
           const l2Token = this.getDestinationTokenForL1Token(l1Token, chainId);

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -30,11 +30,13 @@ import lodash from "lodash";
 import { CONTRACT_ADDRESSES, SLOW_WITHDRAWAL_CHAINS } from "../common";
 import { CombinedRefunds } from "../dataworker/DataworkerUtils";
 
-type TokenDistributionPerL1Token = { [l1Token: string]: { [chainId: number]: BigNumber } };
+type TokenDistribution = { [l2Token: string]: BigNumber };
+type TokenDistributionPerL1Token = { [l1Token: string]: { [chainId: number]: TokenDistribution } };
 
 export type Rebalance = {
   chainId: number;
   l1Token: string;
+  l2Token: string;
   thresholdPct: BigNumber;
   targetPct: BigNumber;
   currentAllocPct: BigNumber;
@@ -95,15 +97,18 @@ export class InventoryClient {
   }
 
   // Get the fraction of funds allocated on each chain.
-  getChainDistribution(l1Token: string): { [chainId: number]: BigNumber } {
+  getChainDistribution(l1Token: string): { [chainId: number]: TokenDistribution } {
     const cumulativeBalance = this.getCumulativeBalance(l1Token);
-    const distribution: { [chainId: number]: BigNumber } = {};
+    const distribution: { [chainId: number]: TokenDistribution } = {};
+
     this.getEnabledChains().forEach((chainId) => {
       // If token doesn't have entry on chain, skip creating an entry for it since we'll likely run into an error
       // later trying to grab the chain equivalent of the L1 token via the HubPoolClient.
       if (chainId === this.hubPoolClient.chainId || this._l1TokenEnabledForChain(l1Token, chainId)) {
+        const l2Token = this.getDestinationTokenForL1Token(l1Token, chainId);
         if (cumulativeBalance.gt(bnZero)) {
-          distribution[chainId] = this.getBalanceOnChainForL1Token(chainId, l1Token)
+          distribution[chainId] ??= {};
+          distribution[chainId][l2Token] = this.getBalanceOnChainForL1Token(chainId, l1Token)
             .mul(this.scalar)
             .div(cumulativeBalance);
         }
@@ -602,15 +607,10 @@ export class InventoryClient {
   }
 
   getPossibleRebalances(): Rebalance[] {
-    const tokenDistributionPerL1Token = this.getTokenDistributionPerL1Token();
-    return this._getPossibleRebalances(tokenDistributionPerL1Token);
-  }
-
-  _getPossibleRebalances(tokenDistributionPerL1Token: TokenDistributionPerL1Token): Rebalance[] {
     const rebalancesRequired: Rebalance[] = [];
 
     // First, compute the rebalances that we would do assuming we have sufficient tokens on L1.
-    for (const l1Token of Object.keys(tokenDistributionPerL1Token)) {
+    for (const l1Token of Object.keys(this.getL1Tokens())) {
       const cumulativeBalance = this.getCumulativeBalance(l1Token);
       if (cumulativeBalance.eq(bnZero)) {
         continue;
@@ -627,12 +627,14 @@ export class InventoryClient {
         const { thresholdPct, targetPct } = this.inventoryConfig.tokenConfig[l1Token][chainId];
         if (currentAllocPct.lt(thresholdPct)) {
           const deltaPct = targetPct.sub(currentAllocPct);
-          const amount = deltaPct.mul(cumulativeBalance).div(this.scalar);
-          const balance = this.tokenClient.getBalance(1, l1Token);
           // Divide by scalar because allocation percent was multiplied by it to avoid rounding errors.
+          const amount = deltaPct.mul(cumulativeBalance).div(this.scalar);
+          const balance = this.tokenClient.getBalance(this.hubPoolClient.chainId, l1Token);
+          const l2Token = this.getDestinationTokenForL1Token(l1Token, chainId);
           rebalancesRequired.push({
             chainId,
             l1Token,
+            l2Token,
             currentAllocPct,
             thresholdPct,
             targetPct,
@@ -662,7 +664,7 @@ export class InventoryClient {
       const tokenDistributionPerL1Token = this.getTokenDistributionPerL1Token();
       this.constructConsideringRebalanceDebugLog(tokenDistributionPerL1Token);
 
-      const rebalancesRequired = this._getPossibleRebalances(tokenDistributionPerL1Token);
+      const rebalancesRequired = this.getPossibleRebalances();
       if (rebalancesRequired.length === 0) {
         this.log("No rebalances required");
         return;
@@ -758,20 +760,21 @@ export class InventoryClient {
       for (const [_chainId, rebalances] of Object.entries(groupedUnexecutedRebalances)) {
         const chainId = Number(_chainId);
         mrkdwn += `*Insufficient amount to rebalance to ${getNetworkName(chainId)}:*\n`;
-        for (const { l1Token, balance, cumulativeBalance, amount } of rebalances) {
+        for (const { l1Token, l2Token, balance, cumulativeBalance, amount } of rebalances) {
           const tokenInfo = this.hubPoolClient.getTokenInfoForL1Token(l1Token);
           if (!tokenInfo) {
             throw new Error(`InventoryClient::rebalanceInventoryIfNeeded no L1 token info for token ${l1Token}`);
           }
           const { symbol, decimals } = tokenInfo;
           const formatter = createFormatFunction(2, 4, false, decimals);
+          const distributionPct = tokenDistributionPerL1Token[l1Token][chainId][l2Token].mul(100);
           mrkdwn +=
             `- ${symbol} transfer blocked. Required to send ` +
             `${formatter(amount.toString())} but relayer has ` +
             `${formatter(balance.toString())} on L1. There is currently ` +
             `${formatter(this.getBalanceOnChainForL1Token(chainId, l1Token).toString())} ${symbol} on ` +
             `${getNetworkName(chainId)} which is ` +
-            `${this.formatWei(tokenDistributionPerL1Token[l1Token][chainId].mul(100).toString())}% of the total ` +
+            `${this.formatWei(distributionPct.toString())}% of the total ` +
             `${formatter(cumulativeBalance.toString())} ${symbol}.` +
             " This chain's pending L1->L2 transfer amount is " +
             `${formatter(
@@ -916,7 +919,7 @@ export class InventoryClient {
     }
   }
 
-  constructConsideringRebalanceDebugLog(distribution: { [l1Token: string]: { [chainId: number]: BigNumber } }): void {
+  constructConsideringRebalanceDebugLog(distribution: TokenDistributionPerL1Token): void {
     const logData: {
       [symbol: string]: {
         [chainId: number]: {
@@ -941,23 +944,26 @@ export class InventoryClient {
       cumulativeBalances[symbol] = formatter(this.getCumulativeBalance(l1Token).toString());
       logData[symbol] ??= {};
 
-      Object.entries(distributionForToken).forEach(([_chainId, amount]) => {
+      Object.keys(distributionForToken).forEach((_chainId) => {
         const chainId = Number(_chainId);
-        logData[symbol][chainId] = {
-          actualBalanceOnChain: formatter(
-            this.getBalanceOnChainForL1Token(chainId, l1Token)
-              .sub(this.crossChainTransferClient.getOutstandingCrossChainTransferAmount(this.relayer, chainId, l1Token))
-              .toString()
-          ),
-          virtualBalanceOnChain: formatter(this.getBalanceOnChainForL1Token(chainId, l1Token).toString()),
-          outstandingTransfers: formatter(
-            this.crossChainTransferClient
-              .getOutstandingCrossChainTransferAmount(this.relayer, chainId, l1Token)
-              .toString()
-          ),
-          tokenShortFalls: formatter(this.getTokenShortFall(l1Token, chainId).toString()),
-          proRataShare: this.formatWei(amount.mul(100).toString()) + "%",
-        };
+
+        Object.entries(distributionForToken[chainId]).forEach(([l2Token, amount]) => {
+          const balanceOnChain = this.getBalanceOnChainForL1Token(chainId, l1Token);
+          const transfers = this.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
+            this.relayer,
+            chainId,
+            l1Token
+          );
+          const actualBalanceOnChain = this.tokenClient.getBalance(chainId, l2Token);
+
+          logData[symbol][chainId] = {
+            actualBalanceOnChain: formatter(actualBalanceOnChain.toString()),
+            virtualBalanceOnChain: formatter(balanceOnChain.toString()),
+            outstandingTransfers: formatter(transfers.toString()),
+            tokenShortFalls: formatter(this.getTokenShortFall(l1Token, chainId).toString()),
+            proRataShare: this.formatWei(amount.mul(100).toString()) + "%",
+          };
+        });
       });
     });
 

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -142,7 +142,8 @@ describe("InventoryClient: Rebalancing inventory", async function () {
         ).to.equal(toBN(0)); // For now no cross-chain transfers
 
         const expectedShare = initialAllocation[chainId][l1Token].mul(toWei(1)).div(initialTotals[l1Token]);
-        expect(tokenDistribution[l1Token][chainId]).to.equal(expectedShare);
+        const l2Token = (l1Token === mainnetWeth ? l2TokensForWeth : l2TokensForUsdc)[chainId];
+        expect(tokenDistribution[l1Token][chainId][l2Token]).to.equal(expectedShare);
       }
     }
   });


### PR DESCRIPTION
InventoryClient._getPossibleRebalances() accepts a TokenDistributionPerL1Token type, but actually only uses the set of L1 tokens defined. This can be sourced elsewhere in order to simplify the implementation and allow TokenDistributionPerL1Token to be updated.

Note that this commit doesn't attempt to make any functional changes to the InventoryClient - it's moreso decoupling the code so that different parts can be updated to support multiple L2 tokens.