### PR TITLE
hotfix(adapter): correct length of parallel arrays

### DIFF
--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -174,6 +174,8 @@ export class ArbitrumAdapter extends CCTPAdapter {
   }
 
   async checkTokenApprovals(address: string, l1Tokens: string[]): Promise<void> {
+    const l1TokenListToApprove = [];
+
     // Note we send the approvals to the L1 Bridge but actually send outbound transfers to the L1 Gateway Router.
     // Note that if the token trying to be approved is not configured in this client (i.e. not in the l1Gateways object)
     // then this will pass null into the checkAndSendTokenApprovals. This method gracefully deals with this case.
@@ -187,10 +189,15 @@ export class ArbitrumAdapter extends CCTPAdapter {
           bridgeAddresses.push(this.getL1CCTPTokenMessengerBridge().address);
         }
         bridgeAddresses.push(this.getL1Bridge(l1Token).address);
+
+        // Push the l1 token to the list of tokens to approve N times, where N is the number of bridges.
+        // I.e. the arrays have to be parallel.
+        l1TokenListToApprove.push(...Array(bridgeAddresses.length).fill(l1Token));
+
         return bridgeAddresses;
       })
       .filter(isDefined);
-    await this.checkAndSendTokenApprovals(address, l1Tokens, associatedL1Bridges);
+    await this.checkAndSendTokenApprovals(address, l1TokenListToApprove, associatedL1Bridges);
   }
 
   sendTokenToTargetChain(

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -115,6 +115,12 @@ export abstract class BaseAdapter {
 
   async checkAndSendTokenApprovals(address: string, l1Tokens: string[], associatedL1Bridges: string[]): Promise<void> {
     this.log("Checking and sending token approvals", { l1Tokens, associatedL1Bridges });
+
+    if (l1Tokens.length !== associatedL1Bridges.length) {
+      this.log("Token and bridge arrays are not the same length", { l1Tokens, associatedL1Bridges }, "error");
+      assert(false, "Token and bridge arrays are not the same length");
+    }
+
     const tokensToApprove: { l1Token: Contract; targetContract: string }[] = [];
     const l1TokenContracts = l1Tokens.map(
       (l1Token) => new Contract(l1Token, ERC20.abi, this.getSigner(this.hubChainId))

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -116,10 +116,7 @@ export abstract class BaseAdapter {
   async checkAndSendTokenApprovals(address: string, l1Tokens: string[], associatedL1Bridges: string[]): Promise<void> {
     this.log("Checking and sending token approvals", { l1Tokens, associatedL1Bridges });
 
-    if (l1Tokens.length !== associatedL1Bridges.length) {
-      this.log("Token and bridge arrays are not the same length", { l1Tokens, associatedL1Bridges }, "error");
-      assert(false, "Token and bridge arrays are not the same length");
-    }
+    assert(l1Tokens.length !== associatedL1Bridges.length, "Token and bridge arrays are not the same length");
 
     const tokensToApprove: { l1Token: Contract; targetContract: string }[] = [];
     const l1TokenContracts = l1Tokens.map(

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -269,6 +269,8 @@ export class PolygonAdapter extends CCTPAdapter {
   }
 
   async checkTokenApprovals(address: string, l1Tokens: string[]): Promise<void> {
+    const l1TokenListToApprove = [];
+
     const associatedL1Bridges = l1Tokens
       .flatMap((l1Token) => {
         if (!this.isSupportedToken(l1Token)) {
@@ -282,10 +284,15 @@ export class PolygonAdapter extends CCTPAdapter {
           bridgeAddresses.push(this.getL1CCTPTokenMessengerBridge().address);
         }
         bridgeAddresses.push(this.getL1Bridge(l1Token).address);
+
+        // Push the l1 token to the list of tokens to approve N times, where N is the number of bridges.
+        // I.e. the arrays have to be parallel.
+        l1TokenListToApprove.push(...Array(bridgeAddresses.length).fill(l1Token));
+
         return bridgeAddresses;
       })
       .filter(isDefined);
-    await this.checkAndSendTokenApprovals(address, l1Tokens, associatedL1Bridges);
+    await this.checkAndSendTokenApprovals(address, l1TokenListToApprove, associatedL1Bridges);
   }
 
   getL1Bridge(l1Token: SupportedL1Token): Contract {

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -175,9 +175,16 @@ export class OpStackAdapter extends BaseAdapter {
   }
 
   async checkTokenApprovals(address: string, l1Tokens: string[]): Promise<void> {
+    const l1TokenListToApprove = [];
     // We need to approve the Atomic depositor to bridge WETH to optimism via the ETH route.
-    const associatedL1Bridges = l1Tokens.flatMap((l1Token) => this.getBridge(l1Token).l1Gateway);
-    await this.checkAndSendTokenApprovals(address, l1Tokens, associatedL1Bridges);
+    const associatedL1Bridges = l1Tokens.flatMap((l1Token) => {
+      const bridges = this.getBridge(l1Token).l1Gateway;
+      // Push the l1 token to the list of tokens to approve N times, where N is the number of bridges.
+      // I.e. the arrays have to be parallel.
+      l1TokenListToApprove.push(...Array(bridges.length).fill(l1Token));
+      return bridges;
+    });
+    await this.checkAndSendTokenApprovals(address, l1TokenListToApprove, associatedL1Bridges);
   }
 
   getBridge(l1Token: string): OpStackBridge {


### PR DESCRIPTION
When we attempt to approve tokens, we have to be sure that the l1Tokens and their associated bridges have the same length. The CCTP change made the bridge list longer than the L1 token list.