### PR TITLE
fix(bridges): Rename l1Gateway to l1Gateways and return string[] always

### DIFF
--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -277,6 +277,7 @@ export class PolygonAdapter extends CCTPAdapter {
           return [];
         }
         if (this.isWeth(l1Token)) {
+          l1TokenListToApprove.push(l1Token);
           return [this.getL1TokenGateway(l1Token)?.address];
         }
         const bridgeAddresses: string[] = [];

--- a/src/clients/bridges/op-stack/DefaultErc20Bridge.ts
+++ b/src/clients/bridges/op-stack/DefaultErc20Bridge.ts
@@ -14,8 +14,8 @@ export class DefaultERC20Bridge implements OpStackBridge {
     this.l2Bridge = new Contract(l2Address, l2Abi, l2SignerOrProvider);
   }
 
-  get l1Gateway(): string {
-    return this.l1Bridge.address;
+  get l1Gateways(): string[] {
+    return [this.l1Bridge.address];
   }
 
   constructL1ToL2Txn(

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -178,9 +178,7 @@ export class OpStackAdapter extends BaseAdapter {
     const l1TokenListToApprove = [];
     // We need to approve the Atomic depositor to bridge WETH to optimism via the ETH route.
     const associatedL1Bridges = l1Tokens.flatMap((l1Token) => {
-      const _bridges = this.getBridge(l1Token).l1Gateway;
-      const bridges = Array.isArray(_bridges) ? _bridges : [this.getBridge(l1Token).l1Gateway as string];
-      assert(Array.isArray(bridges), "OpStackAdapter#checkTokenApprovals: bridges must be an array");
+      const bridges = this.getBridge(l1Token).l1Gateways;
       // Push the l1 token to the list of tokens to approve N times, where N is the number of bridges.
       // I.e. the arrays have to be parallel.
       l1TokenListToApprove.push(...Array(bridges.length).fill(l1Token));

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -178,7 +178,9 @@ export class OpStackAdapter extends BaseAdapter {
     const l1TokenListToApprove = [];
     // We need to approve the Atomic depositor to bridge WETH to optimism via the ETH route.
     const associatedL1Bridges = l1Tokens.flatMap((l1Token) => {
-      const bridges = this.getBridge(l1Token).l1Gateway;
+      const _bridges = this.getBridge(l1Token).l1Gateway;
+      const bridges = Array.isArray(_bridges) ? _bridges : [this.getBridge(l1Token).l1Gateway as string];
+      assert(Array.isArray(bridges), "OpStackAdapter#checkTokenApprovals: bridges must be an array");
       // Push the l1 token to the list of tokens to approve N times, where N is the number of bridges.
       // I.e. the arrays have to be parallel.
       l1TokenListToApprove.push(...Array(bridges.length).fill(l1Token));

--- a/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
+++ b/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
@@ -7,7 +7,7 @@ export interface BridgeTransactionDetails {
 }
 
 export interface OpStackBridge {
-  readonly l1Gateway: string | string[];
+  readonly l1Gateways: string[];
   constructL1ToL2Txn(
     toAddress: string,
     l1Token: string,

--- a/src/clients/bridges/op-stack/UsdcCCTPBridge.ts
+++ b/src/clients/bridges/op-stack/UsdcCCTPBridge.ts
@@ -33,8 +33,8 @@ export class UsdcCCTPBridge implements OpStackBridge {
     return TOKEN_SYMBOLS_MAP._USDC.addresses[this.l2chainId];
   }
 
-  get l1Gateway(): string {
-    return this.l1CctpTokenBridge.address;
+  get l1Gateways(): string[] {
+    return [this.l1CctpTokenBridge.address];
   }
 
   constructL1ToL2Txn(

--- a/src/clients/bridges/op-stack/UsdcTokenSplitterBridge.ts
+++ b/src/clients/bridges/op-stack/UsdcTokenSplitterBridge.ts
@@ -69,7 +69,7 @@ export class UsdcTokenSplitterBridge implements OpStackBridge {
     return events.flat();
   }
 
-  get l1Gateway(): string[] {
-    return [this.cctpBridge.l1Gateway, this.canonicalBridge.l1Gateway];
+  get l1Gateways(): string[] {
+    return [...this.cctpBridge.l1Gateways, ...this.canonicalBridge.l1Gateways];
   }
 }

--- a/src/clients/bridges/op-stack/WethBridge.ts
+++ b/src/clients/bridges/op-stack/WethBridge.ts
@@ -27,8 +27,8 @@ export class WethBridge implements OpStackBridge {
     this.atomicDepositor = new Contract(atomicDepositorAddress, atomicDepositorAbi, l1Signer);
   }
 
-  get l1Gateway(): string {
-    return this.atomicDepositor.address;
+  get l1Gateways(): string[] {
+    return [this.atomicDepositor.address];
   }
 
   constructL1ToL2Txn(

--- a/src/clients/bridges/op-stack/optimism/DaiOptimismBridge.ts
+++ b/src/clients/bridges/op-stack/optimism/DaiOptimismBridge.ts
@@ -22,8 +22,8 @@ export class DaiOptimismBridge implements OpStackBridge {
     this.l2Bridge = new Contract(l2Address, l2Abi, l2SignerOrProvider);
   }
 
-  get l1Gateway(): string {
-    return this.l1Bridge.address;
+  get l1Gateways(): string[] {
+    return [this.l1Bridge.address];
   }
 
   constructL1ToL2Txn(

--- a/src/clients/bridges/op-stack/optimism/SnxOptimismBridge.ts
+++ b/src/clients/bridges/op-stack/optimism/SnxOptimismBridge.ts
@@ -22,8 +22,8 @@ export class SnxOptimismBridge implements OpStackBridge {
     this.l2Bridge = new Contract(l2Address, l2Abi, l2SignerOrProvider);
   }
 
-  get l1Gateway(): string {
-    return this.l1Bridge.address;
+  get l1Gateways(): string[] {
+    return [this.l1Bridge.address];
   }
 
   constructL1ToL2Txn(


### PR DESCRIPTION
## OpStackAdapter fix:
- If `bridges` is type string, we can't call .length on it otherwise we'll inadvertently use the char count of the string

## PolygonAdapter fix:
- Must add WETH to l1Token list before early exiting
