### PR TITLE
fix(monitor): Fix stuck rebalance report grace period logic

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -510,11 +510,8 @@ export class Monitor {
     // Again, this would give false negatives for transfers that have been stuck for longer than one bundle if the
     // current time is within the grace period of last executed bundle. But this is a good trade off for simpler code.
     const lastFullyExecutedBundleTime = lastFullyExecutedBundle.challengePeriodEndTimestamp;
-    const currentTime = await this.clients.hubPoolClient.hubPool.getCurrentTime()
-    if (
-      lastFullyExecutedBundleTime + REBALANCE_FINALIZE_GRACE_PERIOD >
-      currentTime
-    ) {
+    const currentTime = await this.clients.hubPoolClient.hubPool.getCurrentTime();
+    if (lastFullyExecutedBundleTime + REBALANCE_FINALIZE_GRACE_PERIOD > currentTime) {
       this.logger.debug({
         at: "Monitor#checkStuckRebalances",
         message: `Within ${REBALANCE_FINALIZE_GRACE_PERIOD / 60}min grace period of last bundle execution`,

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -510,7 +510,7 @@ export class Monitor {
     // Again, this would give false negatives for transfers that have been stuck for longer than one bundle if the
     // current time is within the grace period of last executed bundle. But this is a good trade off for simpler code.
     const lastFullyExecutedBundleTime = lastFullyExecutedBundle.challengePeriodEndTimestamp;
-    const currentTime = await this.clients.hubPoolClient.hubPool.getCurrentTime();
+    const currentTime = Number(await this.clients.hubPoolClient.hubPool.getCurrentTime());
     if (lastFullyExecutedBundleTime + REBALANCE_FINALIZE_GRACE_PERIOD > currentTime) {
       this.logger.debug({
         at: "Monitor#checkStuckRebalances",

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -510,15 +510,16 @@ export class Monitor {
     // Again, this would give false negatives for transfers that have been stuck for longer than one bundle if the
     // current time is within the grace period of last executed bundle. But this is a good trade off for simpler code.
     const lastFullyExecutedBundleTime = lastFullyExecutedBundle.challengePeriodEndTimestamp;
+    const currentTime = await this.clients.hubPoolClient.hubPool.getCurrentTime()
     if (
       lastFullyExecutedBundleTime + REBALANCE_FINALIZE_GRACE_PERIOD >
-      this.clients.hubPoolClient.latestBlockSearched
+      currentTime
     ) {
       this.logger.debug({
         at: "Monitor#checkStuckRebalances",
         message: `Within ${REBALANCE_FINALIZE_GRACE_PERIOD / 60}min grace period of last bundle execution`,
         lastFullyExecutedBundleTime,
-        currentBlock: this.clients.hubPoolClient.latestBlockSearched,
+        currentTime,
       });
       return;
     }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -35,7 +35,8 @@ import { MonitorClients, updateMonitorClients } from "./MonitorClientHelper";
 import { MonitorConfig } from "./MonitorConfig";
 import { CombinedRefunds } from "../dataworker/DataworkerUtils";
 
-export const REBALANCE_FINALIZE_GRACE_PERIOD = 60 * 60 * 4; // 4 hours.
+export const REBALANCE_FINALIZE_GRACE_PERIOD = 40 * 60; // 40 minutes, which is 50% of the way through an 80 minute
+// bundle frequency.
 export const ALL_CHAINS_NAME = "All chains";
 export const UNKNOWN_TRANSFERS_NAME = "Unknown transfers (incoming, outgoing, net)";
 const ALL_BALANCE_TYPES = [
@@ -511,8 +512,14 @@ export class Monitor {
     const lastFullyExecutedBundleTime = lastFullyExecutedBundle.challengePeriodEndTimestamp;
     if (
       lastFullyExecutedBundleTime + REBALANCE_FINALIZE_GRACE_PERIOD >
-      this.clients.hubPoolClient.hubPool.getCurrentTime()
+      this.clients.hubPoolClient.latestBlockSearched
     ) {
+      this.logger.debug({
+        at: "Monitor#checkStuckRebalances",
+        message: `Within ${REBALANCE_FINALIZE_GRACE_PERIOD / 60}min grace period of last bundle execution`,
+        lastFullyExecutedBundleTime,
+        currentBlock: this.clients.hubPoolClient.latestBlockSearched,
+      });
       return;
     }
 


### PR DESCRIPTION
- this.clients.hubPoolClient.hubPool.getCurrentTime() returns a Promise, so the comparison was never returning true
- the grace period of 4 hours is no longer useful for a bundle period of 1 hour and an 80 minute bundle frequency. This is shortened to 45 mins, meaning don't look for stuck rebalances until we're 45 mins through since the last bundle was executed
