### PR TITLE
improve: Make it clear when we want the L2 versus L1 token info when querying TOKEN_SYMBOLS_MAP

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=16.18.0"
   },
   "dependencies": {
-    "@across-protocol/constants-v2": "1.0.21",
+    "@across-protocol/constants-v2": "1.0.22",
     "@across-protocol/contracts-v2": "2.5.6",
     "@across-protocol/sdk-v2": "0.23.8",
     "@arbitrum/sdk": "^3.1.3",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,7 +1,7 @@
 import { clients, interfaces } from "@across-protocol/sdk-v2";
 import { Contract } from "ethers";
 import winston from "winston";
-import { MakeOptional, EventSearchConfig, getTokenInfo } from "../utils";
+import { MakeOptional, EventSearchConfig, getTokenInfo, getL1TokenInfo } from "../utils";
 import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common";
 import { L1Token } from "../interfaces";
 
@@ -34,8 +34,25 @@ export class HubPoolClient extends clients.HubPoolClient {
     );
   }
 
+  /**
+   * @dev If tokenAddress + chain do not exist in TOKEN_SYMBOLS_MAP then this will throw.
+   * @param tokenAddress Token address on `chain`
+   * @param chain Chain where the `tokenAddress` exists in TOKEN_SYMBOLS_MAP.
+   * @returns Token info for the given token address on the L2 chain including symbol and decimal.
+   */
   getTokenInfoForAddress(tokenAddress: string, chain: number): L1Token {
     return getTokenInfo(tokenAddress, chain);
+  }
+
+  /**
+   * @dev If tokenAddress + chain do not exist in TOKEN_SYMBOLS_MAP then this will throw.
+   * @dev if the token matched in TOKEN_SYMBOLS_MAP does not have an L1 token address then this will throw.
+   * @param tokenAddress Token address on `chain`
+   * @param chain Chain where the `tokenAddress` exists in TOKEN_SYMBOLS_MAP.
+   * @returns Token info for the given token address on the Hub chain including symbol and decimal and L1 address.
+   */
+  getL1TokenInfoForAddress(tokenAddress: string, chain: number): L1Token {
+    return getL1TokenInfo(tokenAddress, chain);
   }
 
   async computeRealizedLpFeePct(deposit: LpFeeRequest): Promise<interfaces.RealizedLpFee> {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -703,12 +703,13 @@ export class Relayer {
         let crossChainLog = "";
         if (this.clients.inventoryClient.isInventoryManagementEnabled() && chainId !== 1) {
           // Shortfalls are mapped to deposit output tokens so look up output token in token symbol map.
-          const l1Token = this.clients.hubPoolClient.getTokenInfoForAddress(token, chainId);
+          const l1Token = this.clients.hubPoolClient.getL1TokenInfoForAddress(token, chainId);
           crossChainLog =
             "There is " +
             formatter(
               this.clients.inventoryClient.crossChainTransferClient
                 .getOutstandingCrossChainTransferAmount(this.relayerAddress, chainId, l1Token.address)
+                // TODO: Add in additional l2Token param here once we can specify it
                 .toString()
             ) +
             ` inbound L1->L2 ${symbol} transfers. `;

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -33,6 +33,21 @@ export function getTokenInfo(l2TokenAddress: string, chainId: number): L1Token {
   };
 }
 
+export function getL1TokenInfo(l2TokenAddress: string, chainId: number): L1Token {
+  const tokenObject = Object.values(TOKEN_SYMBOLS_MAP).find(({ addresses }) => addresses[chainId] === l2TokenAddress);
+  const l1TokenAddress = tokenObject?.addresses[CHAIN_IDs.MAINNET];
+  if (!l1TokenAddress) {
+    throw new Error(
+      `TokenUtils#getL1TokenInfo: Unable to resolve l1 token address in TOKEN_SYMBOLS_MAP for L2 token ${l2TokenAddress} on chain ${chainId}`
+    );
+  }
+  return {
+    address: l1TokenAddress,
+    symbol: tokenObject.symbol,
+    decimals: tokenObject.decimals,
+  };
+}
+
 /**
  * Format the given amount of tokens to the correct number of decimals for the given token symbol.
  * @param symbol The token symbol to format the amount for.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants-v2@1.0.21":
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.21.tgz#631cf132b06bfd96c78f68d1116e3dd95d4891e4"
-  integrity sha512-Blo25dt21KQui2Ht1tfxN9plddOyOHKABff0mj8BEb+KUaFsw6V0oPAVoALNExZd3THrkrL55Ia5cJuYHBX5QA==
+"@across-protocol/constants-v2@1.0.22":
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.22.tgz#b3ca8c6a6276fa36c9ac5fbf17b9f57e4730fa63"
+  integrity sha512-j559oRNY5xNOo2YYb94cPS1sR6dSxKa2YE2rY8SAdagW11tc7aDflV3AAxmCRPyuI7WpB6w5IklBx0JvwNAO0w==
 
 "@across-protocol/constants-v2@^1.0.19":
   version "1.0.20"


### PR DESCRIPTION
Currently we sometimes use the function to grab L2 token info rather than L1 token info.

It doesn't really have any impact because we mostly want just the `symbol` and `decimals` but there is one place in the `Relayer` where we do want the actual L1TokenAddress. I've changed this to call a new function `getL1TokenInfo` instead of `getTokenInfo` which we can use along with the l2 token address already given to query outstanding cross chain transfers correctly following #1469

`getL1TokenInfo` assumes that each token symbols map entry has an L1 token address so this PR also bumps the constants-v3 version that has l1 token addresses for all USDC variants
