### PR TITLE
fix(OpStackAdapter): Filter out available l1 tokens when computing outstanding transfers

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -76,14 +76,17 @@ export class AdapterManager {
     l1Tokens: string[]
   ): Promise<OutstandingTransfers> {
     const adapter = this.adapters[chainId];
+    // @dev The adapter should filter out tokens that are not supported by the adapter, but we do it here as well.
+    const adapterSupportedL1Tokens = l1Tokens.filter((token) =>
+      adapter.supportedTokens.includes(this.hubPoolClient.getTokenInfo(CHAIN_IDs.MAINNET, token).symbol)
+    );
     this.logger.debug({
       at: "AdapterManager",
-      message: "Getting outstandingCrossChainTransfers",
-      chainId,
-      l1Tokens,
+      message: `Getting outstandingCrossChainTransfers for ${chainId}`,
+      adapterSupportedL1Tokens,
       searchConfigs: adapter.getUpdatedSearchConfigs(),
     });
-    return await this.adapters[chainId].getOutstandingCrossChainTransfers(l1Tokens);
+    return await this.adapters[chainId].getOutstandingCrossChainTransfers(adapterSupportedL1Tokens);
   }
 
   async sendTokenCrossChain(

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -87,7 +87,7 @@ export class ArbitrumAdapter extends CCTPAdapter {
     // Skip the token if we can't find the corresponding bridge.
     // This is a valid use case as it's more convenient to check cross chain transfers for all tokens
     // rather than maintaining a list of native bridge-supported tokens.
-    const availableL1Tokens = l1Tokens.filter(this.isSupportedToken.bind(this));
+    const availableL1Tokens = this.filterSupportedTokens(l1Tokens);
 
     const promises: Promise<Event[]>[] = [];
     const cctpOutstandingTransfersPromise: Record<string, Promise<SortableEvent[]>> = {};

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -83,6 +83,10 @@ export abstract class BaseAdapter {
     return this.spokePoolClients[chainId].spokePool.provider;
   }
 
+  filterSupportedTokens(l1Tokens: string[]): string[] {
+    return l1Tokens.filter((l1Token) => this.isSupportedToken(l1Token));
+  }
+
   // Note: this must be called after the SpokePoolClients are updated.
   getUpdatedSearchConfigs(): { l1SearchConfig: EventSearchConfig; l2SearchConfig: EventSearchConfig } {
     const l1LatestBlock = this.spokePoolClients[this.hubChainId].latestBlockSearched;

--- a/src/clients/bridges/LineaAdapter.ts
+++ b/src/clients/bridges/LineaAdapter.ts
@@ -142,7 +142,7 @@ export class LineaAdapter extends BaseAdapter {
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<sdk.interfaces.OutstandingTransfers> {
     const outstandingTransfers: OutstandingTransfers = {};
     const { l1SearchConfig, l2SearchConfig } = this.getUpdatedSearchConfigs();
-    const supportedL1Tokens = l1Tokens.filter(this.isSupportedToken.bind(this));
+    const supportedL1Tokens = this.filterSupportedTokens(l1Tokens);
     await sdk.utils.mapAsync(this.monitoredAddresses, async (address) => {
       // We can only support monitoring the spoke pool contract, not the hub pool.
       if (address === CONTRACT_ADDRESSES[this.hubChainId]?.hubPool?.address) {

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -135,7 +135,7 @@ export class PolygonAdapter extends CCTPAdapter {
     // Skip the tokens if we can't find the corresponding bridge.
     // This is a valid use case as it's more convenient to check cross chain transfers for all tokens
     // rather than maintaining a list of native bridge-supported tokens.
-    const availableTokens = l1Tokens.filter(this.isSupportedToken.bind(this));
+    const availableTokens = this.filterSupportedTokens(l1Tokens);
 
     const promises: Promise<Event[]>[] = [];
     const cctpOutstandingTransfersPromise: Record<string, Promise<SortableEvent[]>> = {};

--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -45,7 +45,7 @@ export class ZKSyncAdapter extends BaseAdapter {
     const hubPool = this.getHubPool();
     const l1ERC20Bridge = this.getL1ERC20BridgeContract();
     const l2ERC20Bridge = this.getL2ERC20BridgeContract();
-    const supportedL1Tokens = l1Tokens.filter(this.isSupportedToken.bind(this));
+    const supportedL1Tokens = this.filterSupportedTokens(l1Tokens);
 
     // Predeclare this function for use below. It is used to process all events that are saved.
     const processEvent = (event: Event) => {

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -74,7 +74,7 @@ export class OpStackAdapter extends BaseAdapter {
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<OutstandingTransfers> {
     const { l1SearchConfig, l2SearchConfig } = this.getUpdatedSearchConfigs();
-    const availableL1Tokens = l1Tokens.filter(this.isSupportedToken.bind(this));
+    const availableL1Tokens = this.filterSupportedTokens(l1Tokens);
 
     const processEvent = (event: Event) => {
       const eventSpread = spreadEventWithBlockNumber(event) as SortableEvent & {

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -74,6 +74,7 @@ export class OpStackAdapter extends BaseAdapter {
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<OutstandingTransfers> {
     const { l1SearchConfig, l2SearchConfig } = this.getUpdatedSearchConfigs();
+    const availableL1Tokens = l1Tokens.filter(this.isSupportedToken.bind(this));
 
     const processEvent = (event: Event) => {
       const eventSpread = spreadEventWithBlockNumber(event) as SortableEvent & {
@@ -90,7 +91,7 @@ export class OpStackAdapter extends BaseAdapter {
     await Promise.all(
       this.monitoredAddresses.map((monitoredAddress) =>
         Promise.all(
-          l1Tokens.map(async (l1Token) => {
+          availableL1Tokens.map(async (l1Token) => {
             const bridge = this.getBridge(l1Token);
 
             const [depositInitiatedResults, depositFinalizedResults] = await Promise.all([
@@ -116,7 +117,7 @@ export class OpStackAdapter extends BaseAdapter {
     this.baseL1SearchConfig.fromBlock = l1SearchConfig.toBlock + 1;
     this.baseL1SearchConfig.fromBlock = l2SearchConfig.toBlock + 1;
 
-    return this.computeOutstandingCrossChainTransfers(l1Tokens);
+    return this.computeOutstandingCrossChainTransfers(availableL1Tokens);
   }
 
   async sendTokenToTargetChain(


### PR DESCRIPTION
We forgot to include this filter line that we have in other adapters.
