### PR TITLE
improve(relayer): Extend deposit confirmation validation

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -413,7 +413,7 @@ export class ProfitClient {
   }
 
   // Return USD amount of fill amount for deposited token, should always return in wei as the units.
-  getFillAmountInUsd(deposit: Deposit, fillAmount: BigNumber): BigNumber {
+  getFillAmountInUsd(deposit: Deposit, fillAmount = deposit.outputAmount): BigNumber {
     const l1TokenInfo = this.hubPoolClient.getTokenInfoForDeposit(deposit);
     if (!l1TokenInfo) {
       const { inputToken } = deposit;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -10,7 +10,7 @@ import {
   refundProposalLiveness,
   randomAddress,
 } from "@across-protocol/contracts-v2/dist/test-utils";
-import { toWei, ZERO_ADDRESS } from "../src/utils";
+import { bnUint256Max, toWei, ZERO_ADDRESS } from "../src/utils";
 
 export {
   amountToDeposit,
@@ -71,5 +71,6 @@ export const IMPOSSIBLE_BLOCK_RANGE = DEFAULT_BLOCK_RANGE_FOR_CHAIN.map((range) 
 export const baseSpeedUpString = "ACROSS-V2-FEE-1.0";
 
 export const defaultMinDepositConfirmations = {
-  default: { [originChainId]: 0, [destinationChainId]: 0 },
+  [originChainId]: [{ usdThreshold: bnUint256Max, minConfirmations: 0 }],
+  [destinationChainId]: [{ usdThreshold: bnUint256Max, minConfirmations: 0 }],
 };


### PR DESCRIPTION
This change makes the relayer more responsive to unfilled deposits without compromising on safety.

It achieves this by filtering each deposit individually for the minumum number of required confirmation requirements before computing the batch deposit confirmation requirements for set of outstanding deposits. This ensures that individual large deposits that have not met the minimum required threshold cannot DoS lower-value deposits that have met their minimums. In hindsight, this logic is completely obvious.

In order to avoid repeatedly sorting and filtering on the deposit confirmation structure, change its format to be a sorted array. This makes it less computationally-expensive (and less annoying) to evaluate MDC requirements.