### PR TITLE
improve(relayer): Warn on incomplete MDC config

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -5,6 +5,7 @@ import { FillStatus, L1Token, V3Deposit, V3DepositWithBlock } from "../interface
 import {
   BigNumber,
   bnZero,
+  bnUint256Max,
   RelayerUnfilledDeposit,
   blockExplorerLink,
   createFormatFunction,
@@ -35,6 +36,19 @@ export class Relayer {
     readonly clients: RelayerClients,
     readonly config: RelayerConfig
   ) {
+    Object.values(clients.spokePoolClients).forEach(({ chainId }) => {
+      if (!isDefined(config.minDepositConfirmations[chainId])) {
+        const chain = getNetworkName(chainId);
+        logger.warn({
+          at: "Relayer::constructor",
+          message: `${chain} deposit confirmation configuration is missing.`,
+        });
+        config.minDepositConfirmations[chainId] = [
+          { usdThreshold: bnUint256Max, minConfirmations: Number.MAX_SAFE_INTEGER },
+        ];
+      }
+    });
+
     this.relayerAddress = getAddress(relayerAddress);
   }
 


### PR DESCRIPTION
Will be useful when new chains are added. It should be hard to miss this since it logs noisily, but it otherwise defaults to a safe value that permits the relayer to continue to operate until the config is fixed.