### PR TITLE
improve(ProviderUtils): Add fields we can ignore when requesting eth_getLogs

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -142,6 +142,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
     // JSON RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges
     // Additional reference: https://github.com/ethers-io/ethers.js/issues/1721
     // 2023-08-31 Added blockHash because of upstream zkSync provider disagreements. Consider removing later.
+    // 2024-05-07 Added l1BatchNumber and logType due to Alchemy. Consider removing later.
     return compareArrayResultsWithIgnoredKeys(
       ["transactionLogIndex", "l1BatchNumber", "logType"],
       rpcResultA,

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -142,7 +142,11 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
     // JSON RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges
     // Additional reference: https://github.com/ethers-io/ethers.js/issues/1721
     // 2023-08-31 Added blockHash because of upstream zkSync provider disagreements. Consider removing later.
-    return compareArrayResultsWithIgnoredKeys(["transactionLogIndex"], rpcResultA, rpcResultB);
+    return compareArrayResultsWithIgnoredKeys(
+      ["transactionLogIndex", "l1BatchNumber", "logType"],
+      rpcResultA,
+      rpcResultB
+    );
   } else {
     return lodash.isEqual(rpcResultA, rpcResultB);
   }


### PR DESCRIPTION
These fields are not set for zksync eth_getLogs responses returned by Alchemy. They are not used in our code so we don't need to compare them for quorum purposes
