### PR TITLE
feat: Add toggleUSDC.ts script for Polygon

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=16.18.0"
   },
   "dependencies": {
-    "@across-protocol/constants-v2": "1.0.22",
+    "@across-protocol/constants-v2": "1.0.24",
     "@across-protocol/contracts-v2": "2.5.6",
     "@across-protocol/sdk-v2": "0.23.8",
     "@arbitrum/sdk": "^3.1.3",

--- a/scripts/toggleUSDC.ts
+++ b/scripts/toggleUSDC.ts
@@ -1,0 +1,153 @@
+/* eslint-disable no-process-exit */
+import { retrieveSignerFromCLIArgs, winston, Logger, assert, TOKEN_SYMBOLS_MAP } from "../src/utils";
+import { CommonConfig, constructClients } from "../src/common";
+
+// Example run commands:
+
+// Disable USDC.e to and from Polygon
+// $ ts-node ./scripts/toggleUSDC.ts
+// \ --wallet mnemonic
+// \ --chainId 137
+// \ --enable false
+
+// Enable Native USDC to and from Polygon
+// $ ts-node ./scripts/toggleDepositRoute.ts
+// \ --wallet mnemonic
+// \ --chainId 137
+// \ --enable true
+
+import minimist from "minimist";
+const args = minimist(process.argv.slice(2), {
+  string: ["chainId"],
+  boolean: ["enable"],
+});
+
+export function getTokenAddressForChain(l2ChainId: number, isNativeUsdc = false): string {
+  if (isNativeUsdc) {
+    const hasL2TokenEntry = TOKEN_SYMBOLS_MAP["_USDC"].addresses[l2ChainId] !== undefined;
+    if (!hasL2TokenEntry) {
+      throw new Error(`No token entry for _USDC on chain ${l2ChainId}`);
+    }
+    return TOKEN_SYMBOLS_MAP["_USDC"].addresses[l2ChainId];
+  } else {
+    const _tokenSymbol = l2ChainId === 8453 ? "USDbC" : "USDC.e";
+    const hasL2TokenEntry = TOKEN_SYMBOLS_MAP[_tokenSymbol].addresses[l2ChainId] !== undefined;
+    if (!hasL2TokenEntry) {
+      throw new Error(`No token entry for ${_tokenSymbol} on chain ${l2ChainId}`);
+    }
+    return TOKEN_SYMBOLS_MAP[_tokenSymbol].addresses[l2ChainId];
+  }
+}
+
+// Get symbol we should use for looking up addresses for l2ChainId in TOKEN_SYMBOLS_MAP.
+export function getTokenSymbol(l2ChainId: number, isNativeUsdc = false): string {
+  if (isNativeUsdc) {
+    return "_USDC";
+  } else {
+    return l2ChainId === 8453 ? "USDbC" : "USDC.e";
+  }
+}
+
+export async function run(logger: winston.Logger): Promise<void> {
+  const chainId = Number(args.chainId);
+  const enable = args.enable;
+  assert(chainId && enable !== undefined);
+
+  // If enabling routes, we want to enable Native USDC if it exists, otherwise enable USDC.e.
+  const nativeUsdc = enable ? TOKEN_SYMBOLS_MAP["_USDC"].addresses[chainId] !== undefined : false;
+  const tokenSymbol = getTokenSymbol(chainId, nativeUsdc);
+  const token = getTokenAddressForChain(chainId, enable);
+  logger.debug({
+    at: "toggleDepositRoutes",
+    message: `Toggling deposit routes to chain ${chainId} for ${
+      nativeUsdc ? "native" : "bridged"
+    } ${tokenSymbol} (${token}) and bridged USDC from all other chains`,
+  });
+
+  const baseSigner = await retrieveSignerFromCLIArgs();
+  const config = new CommonConfig(process.env);
+
+  // Get all deposit routes involving chainId and token
+  const hubPoolLookBack = 7200;
+  const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookBack);
+  const { hubPoolClient } = commonClients;
+  const allChainIds = [1, 10, 137, 324, 42161, 8453, 59144];
+
+  // Save all deposit routes involving chain ID that we want to toggle.
+  /**
+     *  function setDepositRoute(
+            uint256 originChainId,
+            uint256 destinationChainId,
+            address originToken,
+            bool depositsEnabled
+        ) public override nonReentrant onlyOwner {
+     */
+  const routesToDisable: {
+    originChainId: number;
+    destinationChainId: number;
+    originToken: string;
+    depositsEnabled: boolean;
+    originTokenSymbol: string;
+  }[] = [];
+
+  for (const _chainId of allChainIds) {
+    // Toggle deposit routes to/from the target chain
+    if (_chainId === chainId) {
+      continue;
+    }
+
+    // If disabling routes, then assume we are disabling all USDC.e routes.
+    // If enabling routes, then enable _USDC as an `outputToken` on the target chain and USDC.e as an `inputToken`.
+    // These should not throw, otherwise it means there is a missing USDC.e/USDbC entry for the chain.
+    const originTokenSymbol = getTokenSymbol(_chainId, false);
+    const originTokenAddress = getTokenAddressForChain(_chainId, false);
+
+    // Deposit route to target
+    routesToDisable.push({
+      originChainId: _chainId,
+      destinationChainId: chainId,
+      originToken: originTokenAddress,
+      depositsEnabled: enable,
+      originTokenSymbol: originTokenSymbol,
+    });
+    // Deposit route from target
+    routesToDisable.push({
+      originChainId: chainId,
+      destinationChainId: _chainId,
+      originToken: token,
+      depositsEnabled: enable,
+      originTokenSymbol: tokenSymbol,
+    });
+  }
+
+  logger.debug({
+    at: "toggleDepositRoutes",
+    message: `Routes to ${enable ? "enable" : "disable"}`,
+    routesToDisable,
+  });
+
+  // Construct multicall.
+  const data = await Promise.all(
+    routesToDisable.map((route) => {
+      return hubPoolClient.hubPool.populateTransaction.setDepositRoute(
+        route.originChainId,
+        route.destinationChainId,
+        route.originToken,
+        route.depositsEnabled
+      );
+    })
+  );
+  const multicall = await hubPoolClient.hubPool.populateTransaction.multicall(data.map((tx) => tx.data));
+  console.log("Data to pass to HubPool#multicall()", JSON.stringify(multicall.data));
+}
+
+if (require.main === module) {
+  run(Logger)
+    .then(async () => {
+      process.exit(0);
+    })
+    .catch(async (error) => {
+      console.error("Process exited with", error);
+      process.exit(1);
+    });
+}

--- a/scripts/toggleUSDC.ts
+++ b/scripts/toggleUSDC.ts
@@ -23,11 +23,8 @@ const args = minimist(process.argv.slice(2), {
 });
 
 export function getTokenAddressForChain(l2ChainId: number, isNativeUsdc = false): string {
-  if (isNativeUsdc) {
-    const hasL2TokenEntry = TOKEN_SYMBOLS_MAP["_USDC"].addresses[l2ChainId] !== undefined;
-    if (!hasL2TokenEntry) {
-      throw new Error(`No token entry for _USDC on chain ${l2ChainId}`);
-    }
+  const hasL2TokenEntry = TOKEN_SYMBOLS_MAP["_USDC"].addresses[l2ChainId] !== undefined;
+  if (isNativeUsdc && hasL2TokenEntry) {
     return TOKEN_SYMBOLS_MAP["_USDC"].addresses[l2ChainId];
   } else {
     const _tokenSymbol = l2ChainId === 8453 ? "USDbC" : "USDC.e";
@@ -99,8 +96,8 @@ export async function run(logger: winston.Logger): Promise<void> {
     // If disabling routes, then assume we are disabling all USDC.e routes.
     // If enabling routes, then enable _USDC as an `outputToken` on the target chain and USDC.e as an `inputToken`.
     // These should not throw, otherwise it means there is a missing USDC.e/USDbC entry for the chain.
-    const originTokenSymbol = getTokenSymbol(_chainId, false);
-    const originTokenAddress = getTokenAddressForChain(_chainId, false);
+    const originTokenSymbol = getTokenSymbol(_chainId, enable || _chainId === 137);
+    const originTokenAddress = getTokenAddressForChain(_chainId, enable || _chainId === 137);
 
     // Deposit route to target
     routesToDisable.push({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants-v2@1.0.22":
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.22.tgz#b3ca8c6a6276fa36c9ac5fbf17b9f57e4730fa63"
-  integrity sha512-j559oRNY5xNOo2YYb94cPS1sR6dSxKa2YE2rY8SAdagW11tc7aDflV3AAxmCRPyuI7WpB6w5IklBx0JvwNAO0w==
+"@across-protocol/constants-v2@1.0.24":
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.24.tgz#30b7dd898ff6d4848717fd6cf393a10f1f2f40b0"
+  integrity sha512-lDu6rMoTMUolGHwUnX/YkeMcIKB1avd6MnBcyfa4z5DkuF0HCo+7Mbviri2LXW0SOTg/pE26Dvfr1P+HmBUD9A==
 
 "@across-protocol/constants-v2@^1.0.19":
   version "1.0.20"


### PR DESCRIPTION
This is a USDC specific script that assumes we want to produce the following calldata

1. Deposit all routes to/from *Bridged* USDC for a `chainId`
2. Enable all routes to the `chainId` where `inputToken` is Bridged USDC
3. Enable all routes from `chainId` where the `inputToken` Native USDC

Note we'll have to change this script when migrating to CCTP for all other chains because at that point, Native USDC will already be enabled on Polygon. We'll have to do something like:

1. Deposit all routes to/from *Bridged* USDC for a `chainId`, unless that `chainId == 137` then disable from *Native* USDC
2. Enable all routes to the `chainId` where `inputToken` is Native USDC
3. Enable all routes from `chainId` where the `inputToken` Native USDC
