### PR TITLE
feat: Bump config store version to 4

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -3,7 +3,7 @@ import { CHAIN_IDs, TOKEN_SYMBOLS_MAP, ethers } from "../utils";
 // Maximum supported version of the configuration loaded into the Across ConfigStore.
 // It protects bots from running outdated code against newer version of the on-chain config store.
 // @dev Incorrectly setting this value may lead to incorrect behaviour and potential loss of funds.
-export const CONFIG_STORE_VERSION = 3;
+export const CONFIG_STORE_VERSION = 4;
 
 export const RELAYER_MIN_FEE_PCT = 0.0003;
 


### PR DESCRIPTION
This is the minimum version required to support new USDC routes. All relayers should bump this version consciously when they are ready to support Native USDC on L2s. This means taking repayments in Native USDC instead of Bridged USDC. This also means that if outputToken = address(0), that the new default output token is Native USDC for routes where Native USDC is enabled

Do not merge this until the first Native USDC pool rebalance route is enabled for Polygon