### PR TITLE
fix(Monitor): Be robust to whacky output tokens

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -192,9 +192,18 @@ export class Monitor {
       const chainId = parseInt(chainIdStr);
       mrkdwn += `*Destination: ${getNetworkName(chainId)}*\n`;
       for (const tokenAddress of Object.keys(amountByToken)) {
-        const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(tokenAddress, chainId);
+        let symbol: string;
+        let unfilledAmount: string;
+        try {
+          let decimals: number;
+          ({ symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(tokenAddress, chainId));
+          unfilledAmount = convertFromWei(amountByToken[tokenAddress].toString(), decimals);
+        } catch {
+          symbol = "unknown";
+          unfilledAmount = amountByToken[tokenAddress].toString();
+        }
+
         // Convert to number of tokens for readability.
-        const unfilledAmount = convertFromWei(amountByToken[tokenAddress].toString(), decimals);
         mrkdwn += `${symbol}: ${unfilledAmount}\n`;
       }
     }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -199,7 +199,7 @@ export class Monitor {
           ({ symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForAddress(tokenAddress, chainId));
           unfilledAmount = convertFromWei(amountByToken[tokenAddress].toString(), decimals);
         } catch {
-          symbol = "unknown";
+          symbol = tokenAddress; // Using the address helps investigation.
           unfilledAmount = amountByToken[tokenAddress].toString();
         }
 


### PR DESCRIPTION
Dong-Ha identified that a deposit on Arbitrum incorrectly used the Arbitrum USDC.e address as the outputToken for a fill on Base. In case the outputToken can't be resolved, fall back to symbol "unknown" and log the raw amount.