### PR TITLE
fix(InventoryClient): Ignore mainnet in rebalance evaluation

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -701,7 +701,7 @@ export class InventoryClient {
   }
 
   getPossibleRebalances(): Rebalance[] {
-    const chainIds = this.getEnabledChains();
+    const chainIds = this.getEnabledL2Chains();
     const rebalancesRequired: Rebalance[] = [];
 
     for (const l1Token of this.getL1Tokens()) {


### PR DESCRIPTION
The set of rebalance chainIds was incorrectly changed from `getEnabledL2Chains()` to `getEnabledChains()` in the previous commit.