### PR TITLE
improve(InventoryClient): Log L2 token balances separately

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -1007,11 +1007,13 @@ export class InventoryClient {
     const logData: {
       [symbol: string]: {
         [chainId: number]: {
-          actualBalanceOnChain: string;
-          virtualBalanceOnChain: string;
-          outstandingTransfers: string;
-          tokenShortFalls: string;
-          proRataShare: string;
+          [l2TokenAddress: string]: {
+            actualBalanceOnChain: string;
+            virtualBalanceOnChain: string;
+            outstandingTransfers: string;
+            tokenShortFalls: string;
+            proRataShare: string;
+          };
         };
       };
     } = {};
@@ -1030,6 +1032,7 @@ export class InventoryClient {
 
       Object.keys(distributionForToken).forEach((_chainId) => {
         const chainId = Number(_chainId);
+        logData[symbol][chainId] ??= {};
 
         Object.entries(distributionForToken[chainId]).forEach(([l2Token, amount]) => {
           const balanceOnChain = this.getBalanceOnChain(chainId, l1Token, l2Token);
@@ -1040,8 +1043,7 @@ export class InventoryClient {
             l2Token
           );
           const actualBalanceOnChain = this.tokenClient.getBalance(chainId, l2Token);
-
-          logData[symbol][chainId] = {
+          logData[symbol][chainId][l2Token] = {
             actualBalanceOnChain: formatter(actualBalanceOnChain.toString()),
             virtualBalanceOnChain: formatter(balanceOnChain.toString()),
             outstandingTransfers: formatter(transfers.toString()),

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -214,7 +214,7 @@ describe("InventoryClient: Rebalancing inventory", async function () {
     expect(lastSpyLogIncludes(spy, "No rebalances required")).to.be.true;
     // We should see a log for Arbitrum that shows the actual balance after the relay concluded and the share. The
     // actual balance should be listed above at 1015. share should be 1015/(14500) = 0.7 (initial total - withdrawAmount).
-    expect(spyLogIncludes(spy, -2, `"${ARBITRUM}":{"actualBalanceOnChain":"1,015.00"`)).to.be.true;
+    expect(spyLogIncludes(spy, -2, '"actualBalanceOnChain":"1,015.00"')).to.be.true;
     expect(spyLogIncludes(spy, -2, '"proRataShare":"7.00%"')).to.be.true;
   });
 


### PR DESCRIPTION
Logs correctly the case where there are multiple L2 tokens defined in the token config for a single l1 token
