### PR TITLE
fix: Bump constants v3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=16.18.0"
   },
   "dependencies": {
-    "@across-protocol/constants-v2": "1.0.24",
+    "@across-protocol/constants-v2": "1.0.25",
     "@across-protocol/contracts-v2": "2.5.6",
     "@across-protocol/sdk-v2": "0.23.10",
     "@arbitrum/sdk": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants-v2@1.0.24":
-  version "1.0.24"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.24.tgz#30b7dd898ff6d4848717fd6cf393a10f1f2f40b0"
-  integrity sha512-lDu6rMoTMUolGHwUnX/YkeMcIKB1avd6MnBcyfa4z5DkuF0HCo+7Mbviri2LXW0SOTg/pE26Dvfr1P+HmBUD9A==
+"@across-protocol/constants-v2@1.0.25":
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.25.tgz#b55b77332591260b9a7373071e0475abcfbae4a8"
+  integrity sha512-flUhzCsHsIan3NlNNCFDrFHl8QhtRQUzUU7VSa/XEUXqcLwIUJzkpAr+yX1+wGzYd2odlFYZ4MKqGkzqdkvmGA==
 
 "@across-protocol/constants-v2@^1.0.19":
   version "1.0.20"


### PR DESCRIPTION
Get access to _USDC symbol in TOKEN_EQUIVALENCY_REMAPPING
