### PR TITLE
fix(finalizer): Look up L1TokenInfo using TOKEN_SYMBOLS_MAP

### DIFF
--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -10,6 +10,7 @@ import {
   getCurrentTime,
   getRedisCache,
   getBlockForTimestamp,
+  getL1TokenInfo,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
@@ -55,12 +56,7 @@ async function multicallArbitrumFinalizations(
   const finalizableMessages = await getFinalizableMessages(logger, tokensBridged, hubSigner);
   const callData = await Promise.all(finalizableMessages.map((message) => finalizeArbitrum(message.message)));
   const crossChainTransfers = finalizableMessages.map(({ info: { l2TokenAddress, amountToReturn } }) => {
-    const l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      l2TokenAddress,
-      CHAIN_ID,
-      hubPoolClient.latestBlockSearched
-    );
-    const l1TokenInfo = hubPoolClient.getTokenInfo(1, l1TokenCounterpart);
+    const l1TokenInfo = getL1TokenInfo(l2TokenAddress, CHAIN_ID);
     const amountFromWei = convertFromWei(amountToReturn.toString(), l1TokenInfo.decimals);
     const withdrawal: CrossChainMessage = {
       originationChainId: CHAIN_ID,

--- a/src/finalizer/utils/linea/l2ToL1.ts
+++ b/src/finalizer/utils/linea/l2ToL1.ts
@@ -3,7 +3,7 @@ import { Wallet } from "ethers";
 import { groupBy } from "lodash";
 
 import { HubPoolClient, SpokePoolClient } from "../../../clients";
-import { Signer, winston, convertFromWei } from "../../../utils";
+import { Signer, winston, convertFromWei, getL1TokenInfo } from "../../../utils";
 import { FinalizerPromise, CrossChainMessage } from "../../types";
 import { TokensBridged } from "../../../interfaces";
 import {
@@ -103,12 +103,7 @@ export async function lineaL2ToL1Finalizer(
   // Populate cross chain transfers for claimed messages
   const transfers = claimable.map(({ tokensBridged }) => {
     const { l2TokenAddress, amountToReturn } = tokensBridged;
-    const l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      l2TokenAddress,
-      l2ChainId,
-      hubPoolClient.latestBlockSearched
-    );
-    const { decimals, symbol: l1TokenSymbol } = hubPoolClient.getTokenInfo(l1ChainId, l1TokenCounterpart);
+    const { decimals, symbol: l1TokenSymbol } = getL1TokenInfo(l2TokenAddress, l2ChainId);
     const amountFromWei = convertFromWei(amountToReturn.toString(), decimals);
     const transfer: CrossChainMessage = {
       originationChainId: l2ChainId,

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -10,6 +10,7 @@ import {
   getBlockForTimestamp,
   getCachedProvider,
   getCurrentTime,
+  getL1TokenInfo,
   getNetworkName,
   getRedisCache,
   getUniqueLogIndex,
@@ -217,13 +218,6 @@ async function getOptimismFinalizableMessages(
   );
 }
 
-function getL1TokenInfoForOptimismToken(chainId: OVM_CHAIN_ID, hubPoolClient: HubPoolClient, l2Token: string): L1Token {
-  return hubPoolClient.getL1TokenInfoForL2Token(
-    SpokePoolClient.getExecutedRefundLeafL2Token(chainId, l2Token),
-    chainId
-  );
-}
-
 async function finalizeOptimismMessage(
   _chainId: OVM_CHAIN_ID,
   crossChainMessenger: OVM_CROSS_CHAIN_MESSENGER,
@@ -274,7 +268,7 @@ async function multicallOptimismFinalizations(
     )
   );
   const withdrawals = finalizableMessages.map((message) => {
-    const l1TokenInfo = getL1TokenInfoForOptimismToken(chainId, hubPoolClient, message.event.l2TokenAddress);
+    const l1TokenInfo = getL1TokenInfo(message.event.l2TokenAddress, chainId);
     const amountFromWei = convertFromWei(message.event.amountToReturn.toString(), l1TokenInfo.decimals);
     const withdrawal: CrossChainMessage = {
       originationChainId: chainId,
@@ -306,7 +300,7 @@ async function multicallOptimismL1Proofs(
     provableMessages.map((message) => proveOptimismMessage(chainId, crossChainMessenger, message, message.logIndex))
   );
   const withdrawals = provableMessages.map((message) => {
-    const l1TokenInfo = getL1TokenInfoForOptimismToken(chainId, hubPoolClient, message.event.l2TokenAddress);
+    const l1TokenInfo = getL1TokenInfo(message.event.l2TokenAddress, chainId);
     const amountFromWei = convertFromWei(message.event.amountToReturn.toString(), l1TokenInfo.decimals);
     const proof: CrossChainMessage = {
       originationChainId: chainId,

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { groupBy } from "lodash";
 import * as optimismSDK from "@eth-optimism/sdk";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
-import { L1Token, TokensBridged } from "../../interfaces";
+import { TokensBridged } from "../../interfaces";
 import {
   BigNumber,
   chainIsOPStack,

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -9,6 +9,7 @@ import {
   getBlockForTimestamp,
   getCurrentTime,
   getEthAddressForChain,
+  getL1TokenInfo,
   getRedisCache,
   getUniqueLogIndex,
   winston,
@@ -65,12 +66,7 @@ export async function zkSyncFinalizer(
   const txns = await prepareFinalizations(l1ChainId, l2ChainId, withdrawalParams);
 
   const withdrawals = candidates.map(({ l2TokenAddress, amountToReturn }) => {
-    const l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      l2TokenAddress,
-      l2ChainId,
-      hubPoolClient.latestBlockSearched
-    );
-    const { decimals, symbol: l1TokenSymbol } = hubPoolClient.getTokenInfo(l1ChainId, l1TokenCounterpart);
+    const { decimals, symbol: l1TokenSymbol } = getL1TokenInfo(l2TokenAddress, l2ChainId);
     const amountFromWei = convertFromWei(amountToReturn.toString(), decimals);
     const withdrawal: CrossChainMessage = {
       originationChainId: l2ChainId,


### PR DESCRIPTION
These l2-->l2 finalizers will all break when trying to finalize an l2 token that is no longer linked to l1 via PoolRebalanceRoutes, like USDC.e for 137,10,8453,42161

We haven't seen this yet because polygon, the only CCTP enabled chain so far, has not withdawn any funds from L2 to L1
