### PR TITLE
fix(Dataworker): Use correct pool rebalance route token mapping

### DIFF
--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -343,7 +343,11 @@ export function _buildRelayerRefundRoot(
         return;
       }
 
-      const l2TokenCounterpart = clients.hubPoolClient.getL2TokenForL1TokenAtBlock(leaf.l1Tokens[index], leaf.chainId, endBlockForMainnet);
+      const l2TokenCounterpart = clients.hubPoolClient.getL2TokenForL1TokenAtBlock(
+        leaf.l1Tokens[index],
+        leaf.chainId,
+        endBlockForMainnet
+      );
       // If we've already seen this leaf, then skip.
       const existingLeaf = relayerRefundLeaves.find(
         (relayerRefundLeaf) =>

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -343,7 +343,7 @@ export function _buildRelayerRefundRoot(
         return;
       }
 
-      const l2TokenCounterpart = clients.hubPoolClient.getL2TokenForL1TokenAtBlock(leaf.l1Tokens[index], leaf.chainId);
+      const l2TokenCounterpart = clients.hubPoolClient.getL2TokenForL1TokenAtBlock(leaf.l1Tokens[index], leaf.chainId, endBlockForMainnet);
       // If we've already seen this leaf, then skip.
       const existingLeaf = relayerRefundLeaves.find(
         (relayerRefundLeaf) =>

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -420,7 +420,7 @@ export async function _buildPoolRebalanceRoot(
         const l1TokenCounterpart = clients.hubPoolClient.getL1TokenForL2TokenAtBlock(
           l2TokenAddress,
           repaymentChainId,
-          latestMainnetBlock
+          mainnetBundleEndBlock
         );
 
         updateRunningBalance(runningBalances, repaymentChainId, l1TokenCounterpart, totalRefundAmount);
@@ -443,7 +443,7 @@ export async function _buildPoolRebalanceRoot(
         const l1TokenCounterpart = clients.hubPoolClient.getL1TokenForL2TokenAtBlock(
           outputToken,
           destinationChainId,
-          latestMainnetBlock
+          mainnetBundleEndBlock
         );
         const lpFee = deposit.lpFeePct.mul(deposit.inputAmount).div(fixedPointAdjustment);
         updateRunningBalance(runningBalances, destinationChainId, l1TokenCounterpart, deposit.inputAmount.sub(lpFee));
@@ -467,7 +467,7 @@ export async function _buildPoolRebalanceRoot(
         const l1TokenCounterpart = clients.hubPoolClient.getL1TokenForL2TokenAtBlock(
           outputToken,
           destinationChainId,
-          latestMainnetBlock
+          mainnetBundleEndBlock
         );
         const lpFee = deposit.lpFeePct.mul(deposit.inputAmount).div(fixedPointAdjustment);
         updateRunningBalance(runningBalances, destinationChainId, l1TokenCounterpart, lpFee.sub(deposit.inputAmount));
@@ -503,7 +503,7 @@ export async function _buildPoolRebalanceRoot(
         const l1TokenCounterpart = clients.hubPoolClient.getL1TokenForL2TokenAtBlock(
           inputToken,
           originChainId,
-          latestMainnetBlock
+          mainnetBundleEndBlock
         );
         updateRunningBalance(runningBalances, originChainId, l1TokenCounterpart, deposit.inputAmount);
       });


### PR DESCRIPTION
This should only cause bugs currently when validating older bundles pre-pool rebalance route upgrade, but thsoe bundles have been fully 
executed already so the warnings are noise. This fixes warnings where older bundle roots can't be reconstructed bc the wrong pool 
rebalacne route is being used to map tokens
