### PR TITLE
improve(indexer): Additional debug logging

### DIFF
--- a/src/libexec/RelayerSpokePoolIndexer.ts
+++ b/src/libexec/RelayerSpokePoolIndexer.ts
@@ -248,12 +248,12 @@ async function run(argv: string[]): Promise<void> {
   const spokePool = await utils.getSpokePoolContract(chainId);
 
   process.on("SIGHUP", () => {
-    logger.debug({ at: "Relayer#run", message: "Received SIGHUP, stopping..." });
+    logger.debug({ at: "Relayer#run", message: `Received SIGHUP in ${chain} listener, stopping...` });
     stop = true;
   });
 
   process.on("disconnect", () => {
-    logger.debug({ at: "Relayer::run", message: "Parent disconnected, stopping..." });
+    logger.debug({ at: "Relayer::run", message: `${chain} parent disconnected, stopping...` });
     stop = true;
   });
 
@@ -310,11 +310,12 @@ if (require.main === module) {
       process.exitCode = NODE_SUCCESS;
     })
     .catch((error) => {
-      logger.error({ at: "RelayerSpokePoolIndexer", message: "Process exited with error.", error });
+      logger.error({ at: "RelayerSpokePoolIndexer", message: `${chain} listener exited with error.`, error });
       process.exitCode = NODE_APP_ERR;
     })
     .finally(async () => {
       await disconnectRedisClients();
+      logger.error({ at: "RelayerSpokePoolIndexer", message: `Exiting ${chain} listener.` });
       exit(process.exitCode);
     });
 }


### PR DESCRIPTION
PD alerts are occasionally raised regarding a 1200 second timeout on the fast relayer. Logs indicate that the relayer is actually exiting, so additional logs are needed in the external listener process to isolate the issue.