### PR TITLE
fix(TokenClient): Use correct signer on direct token queries

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -172,7 +172,7 @@ export class TokenClient {
   }
 
   resolveRemoteTokens(chainId: number, hubPoolTokens: L1Token[]): Contract[] {
-    const { signer } = this.hubPoolClient.hubPool;
+    const { signer } = this.spokePoolClients[chainId].spokePool;
 
     if (chainId === this.hubPoolClient.chainId) {
       return hubPoolTokens.map(({ address }) => new Contract(address, ERC20.abi, signer));

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -174,6 +174,10 @@ export class TokenClient {
   resolveRemoteTokens(chainId: number, hubPoolTokens: L1Token[]): Contract[] {
     const { signer } = this.hubPoolClient.hubPool;
 
+    if (chainId === this.hubPoolClient.chainId) {
+      return hubPoolTokens.map(({ address }) => new Contract(address, ERC20.abi, signer));
+    }
+
     const tokens = hubPoolTokens
       .map(({ symbol, address }) => {
         let tokenAddrs: string[] = [];
@@ -282,13 +286,11 @@ export class TokenClient {
 
     const { relayerAddress } = this;
     const tokenData = Object.fromEntries(
-      await Promise.all(
-        await sdkUtils.mapAsync(this.resolveRemoteTokens(chainId, hubPoolTokens), async (token: Contract) => {
-          const balance: BigNumber = await token.balanceOf(relayerAddress);
-          const allowance = await this._getAllowance(spokePoolClient, token);
-          return [token.address, { balance, allowance }];
-        })
-      )
+      await sdkUtils.mapAsync(this.resolveRemoteTokens(chainId, hubPoolTokens), async (token: Contract) => {
+        const balance: BigNumber = await token.balanceOf(relayerAddress);
+        const allowance = await this._getAllowance(spokePoolClient, token);
+        return [token.address, { balance, allowance }];
+      })
     );
 
     return tokenData;


### PR DESCRIPTION
The recent change to use multicall incorrectly uses the hub chain signer for remote chain tokens. This results in very confusing and counter-intuitive failures when the remote chain does not support multicall.

Also:
- There's no need to query the HubPoolClient for L2 token addresses when the target chain is the hub chain itself.
- Remove a redundant Promise.all().