### PR TITLE
fix(Finalizer): Dedup transaction hash list when creating list of transactions to query for CCTP l2->l1 transactions

### DIFF
--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -30,7 +30,7 @@ export async function arbitrumOneFinalizer(
   // Arbitrum takes 7 days to finalize withdrawals, so don't look up events younger than that.
   const redis = await getRedisCache(logger);
   const [fromBlock, toBlock] = await Promise.all([
-    getBlockForTimestamp(chainId, getCurrentTime() - 9 * 60 * 60 * 24, undefined, redis),
+    getBlockForTimestamp(chainId, getCurrentTime() - 14 * 60 * 60 * 24, undefined, redis),
     getBlockForTimestamp(chainId, getCurrentTime() - 7 * 60 * 60 * 24, undefined, redis),
   ]);
   logger.debug({

--- a/src/finalizer/utils/cctp/l1ToL2.ts
+++ b/src/finalizer/utils/cctp/l1ToL2.ts
@@ -32,9 +32,7 @@ export async function cctpL1toL2Finalizer(
   spokePoolClient: SpokePoolClient,
   l1ToL2AddressesToFinalize: string[]
 ): Promise<FinalizerPromise> {
-  // Let's just assume for now CCTP transfers don't take longer than 1 day and can
-  // happen very quickly.
-  const lookback = getCurrentTime() - 60 * 60 * 24;
+  const lookback = getCurrentTime() - 60 * 60 * 24 * 7;
   const redis = await getRedisCache(logger);
   const fromBlock = await getBlockForTimestamp(hubPoolClient.chainId, lookback, undefined, redis);
   logger.debug({

--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -8,6 +8,7 @@ import {
   Signer,
   TOKEN_SYMBOLS_MAP,
   assert,
+  compareAddressesSimple,
   getBlockForTimestamp,
   getCurrentTime,
   getNetworkName,
@@ -75,7 +76,7 @@ async function resolveRelatedTxnReceipts(
     .filter(
       (bridgeEvent) =>
         bridgeEvent.blockNumber >= latestBlockToFinalize &&
-        bridgeEvent.l2TokenAddress === TOKEN_SYMBOLS_MAP._USDC.addresses[sourceChainId]
+        compareAddressesSimple(bridgeEvent.l2TokenAddress, TOKEN_SYMBOLS_MAP._USDC.addresses[sourceChainId])
     )
     .forEach((bridgeEvent) => uniqueTxnHashes.add(bridgeEvent.transactionHash));
 

--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -26,7 +26,7 @@ export async function cctpL2toL1Finalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient
 ): Promise<FinalizerPromise> {
-  const lookback = getCurrentTime() - 60 * 60 * 24;
+  const lookback = getCurrentTime() - 60 * 60 * 24 * 7;
   const redis = await getRedisCache(logger);
   const fromBlock = await getBlockForTimestamp(hubPoolClient.chainId, lookback, undefined, redis);
   logger.debug({

--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -25,8 +25,6 @@ export async function cctpL2toL1Finalizer(
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient
 ): Promise<FinalizerPromise> {
-  // Let's just assume for now CCTP transfers don't take longer than 1 day and can
-  // happen very quickly.
   const lookback = getCurrentTime() - 60 * 60 * 24;
   const redis = await getRedisCache(logger);
   const fromBlock = await getBlockForTimestamp(hubPoolClient.chainId, lookback, undefined, redis);

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -53,8 +53,8 @@ export async function opStackFinalizer(
   // - Don't try to withdraw tokens that are not past the 7 day challenge period
   const redis = await getRedisCache(logger);
   const [earliestBlockToFinalize, latestBlockToProve] = await Promise.all([
+    getBlockForTimestamp(chainId, getCurrentTime() - 14 * 60 * 60 * 24, undefined, redis),
     getBlockForTimestamp(chainId, getCurrentTime() - 7 * 60 * 60 * 24, undefined, redis),
-    getBlockForTimestamp(chainId, getCurrentTime() - 60 * 60 * 24, undefined, redis),
   ]);
   const { recentTokensBridgedEvents = [], olderTokensBridgedEvents = [] } = groupBy(
     spokePoolClient.getTokensBridged(),

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -46,7 +46,7 @@ export async function polygonFinalizer(
   const { chainId } = spokePoolClient;
 
   const posClient = await getPosClient(signer);
-  const lookback = getCurrentTime() - 60 * 60 * 24;
+  const lookback = getCurrentTime() - 60 * 60 * 24 * 7;
   const redis = await getRedisCache(logger);
   const fromBlock = await getBlockForTimestamp(chainId, lookback, undefined, redis);
 

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -47,7 +47,7 @@ export async function zkSyncFinalizer(
   // older than 2 days and earlier than 1 day.
   const redis = await getRedisCache(logger);
   const [fromBlock, toBlock] = await Promise.all([
-    getBlockForTimestamp(l2ChainId, getCurrentTime() - 2 * 60 * 60 * 24, undefined, redis),
+    getBlockForTimestamp(l2ChainId, getCurrentTime() - 8 * 60 * 60 * 24, undefined, redis),
     getBlockForTimestamp(l2ChainId, getCurrentTime() - 1 * 60 * 60 * 24, undefined, redis),
   ]);
   logger.debug({


### PR DESCRIPTION
We’re not de-duping the set of txn receipts to query for CCTP l2 to l1 deposits, but we do this in the l1 to l2 direciton.

What’s unique for L2 to L1 is we look for SpokePool.TokensBridged() events but we forget there might be multiple of these in the same block
