### PR TITLE
improve(finalizer): Increase margin of error for finalizer to cover for multiple day down-time

### DIFF
--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -30,7 +30,7 @@ export async function arbitrumOneFinalizer(
   // Arbitrum takes 7 days to finalize withdrawals, so don't look up events younger than that.
   const redis = await getRedisCache(logger);
   const [fromBlock, toBlock] = await Promise.all([
-    getBlockForTimestamp(chainId, getCurrentTime() - 9 * 60 * 60 * 24, undefined, redis),
+    getBlockForTimestamp(chainId, getCurrentTime() - 14 * 60 * 60 * 24, undefined, redis),
     getBlockForTimestamp(chainId, getCurrentTime() - 7 * 60 * 60 * 24, undefined, redis),
   ]);
   logger.debug({

--- a/src/finalizer/utils/cctp/l1ToL2.ts
+++ b/src/finalizer/utils/cctp/l1ToL2.ts
@@ -32,9 +32,7 @@ export async function cctpL1toL2Finalizer(
   spokePoolClient: SpokePoolClient,
   l1ToL2AddressesToFinalize: string[]
 ): Promise<FinalizerPromise> {
-  // Let's just assume for now CCTP transfers don't take longer than 1 day and can
-  // happen very quickly.
-  const lookback = getCurrentTime() - 60 * 60 * 24;
+  const lookback = getCurrentTime() - 60 * 60 * 24 * 7;
   const redis = await getRedisCache(logger);
   const fromBlock = await getBlockForTimestamp(hubPoolClient.chainId, lookback, undefined, redis);
   logger.debug({

--- a/src/finalizer/utils/cctp/l2ToL1.ts
+++ b/src/finalizer/utils/cctp/l2ToL1.ts
@@ -27,7 +27,7 @@ export async function cctpL2toL1Finalizer(
 ): Promise<FinalizerPromise> {
   // Let's just assume for now CCTP transfers don't take longer than 1 day and can
   // happen very quickly.
-  const lookback = getCurrentTime() - 60 * 60 * 24;
+  const lookback = getCurrentTime() - 60 * 60 * 24 * 7;
   const redis = await getRedisCache(logger);
   const fromBlock = await getBlockForTimestamp(hubPoolClient.chainId, lookback, undefined, redis);
   logger.debug({

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -53,8 +53,8 @@ export async function opStackFinalizer(
   // - Don't try to withdraw tokens that are not past the 7 day challenge period
   const redis = await getRedisCache(logger);
   const [earliestBlockToFinalize, latestBlockToProve] = await Promise.all([
+    getBlockForTimestamp(chainId, getCurrentTime() - 14 * 60 * 60 * 24, undefined, redis),
     getBlockForTimestamp(chainId, getCurrentTime() - 7 * 60 * 60 * 24, undefined, redis),
-    getBlockForTimestamp(chainId, getCurrentTime() - 60 * 60 * 24, undefined, redis),
   ]);
   const { recentTokensBridgedEvents = [], olderTokensBridgedEvents = [] } = groupBy(
     spokePoolClient.getTokensBridged(),

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -46,7 +46,7 @@ export async function polygonFinalizer(
   const { chainId } = spokePoolClient;
 
   const posClient = await getPosClient(signer);
-  const lookback = getCurrentTime() - 60 * 60 * 24;
+  const lookback = getCurrentTime() - 60 * 60 * 24 * 7;
   const redis = await getRedisCache(logger);
   const fromBlock = await getBlockForTimestamp(chainId, lookback, undefined, redis);
 

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -47,7 +47,7 @@ export async function zkSyncFinalizer(
   // older than 2 days and earlier than 1 day.
   const redis = await getRedisCache(logger);
   const [fromBlock, toBlock] = await Promise.all([
-    getBlockForTimestamp(l2ChainId, getCurrentTime() - 2 * 60 * 60 * 24, undefined, redis),
+    getBlockForTimestamp(l2ChainId, getCurrentTime() - 8 * 60 * 60 * 24, undefined, redis),
     getBlockForTimestamp(l2ChainId, getCurrentTime() - 1 * 60 * 60 * 24, undefined, redis),
   ]);
   logger.debug({


### PR DESCRIPTION
Currently the finalizer is optimized for run-time speed and tries to look over as short of an event search window as possible.

However, this provides very little margin for error in case the finalizer goes down for multiple days.

this PR gives every finalizer 7 days to look over events for outstanding finalizations
