### PR TITLE
fix(finalizer): polygon

### DIFF
--- a/src/finalizer/utils/linea/l1ToL2.ts
+++ b/src/finalizer/utils/linea/l1ToL2.ts
@@ -40,9 +40,7 @@ export async function lineaL1ToL2Finalizer(
   );
 
   // Optimize block range for querying Linea's MessageSent events on L1.
-  // We want to conservatively query for events that are between 0 and 24 hours old
-  // because Linea L1->L2 messages are claimable after ~20 mins.
-  const { fromBlock, toBlock } = await getBlockRangeByHoursOffsets(l1ChainId, 24, 0);
+  const { fromBlock, toBlock } = await getBlockRangeByHoursOffsets(l1ChainId, 24 * 7, 0);
   logger.debug({
     at: "Finalizer#LineaL1ToL2Finalizer",
     message: "Linea MessageSent event filter",

--- a/src/finalizer/utils/linea/l2ToL1.ts
+++ b/src/finalizer/utils/linea/l2ToL1.ts
@@ -27,9 +27,8 @@ export async function lineaL2ToL1Finalizer(
   const getMessagesWithStatusByTxHash = makeGetMessagesWithStatusByTxHash(l2Contract, l1ClaimingService);
 
   // Optimize block range for querying relevant source events on L2.
-  // We want to conservatively query for events that are between 8 and 72 hours old
-  // because Linea L2->L1 messages are claimable after 6 - 32 hours
-  const { fromBlock, toBlock } = await getBlockRangeByHoursOffsets(l2ChainId, 72, 8);
+  // Linea L2->L1 messages are claimable after 6 - 32 hours
+  const { fromBlock, toBlock } = await getBlockRangeByHoursOffsets(l2ChainId, 24 * 8, 6);
   logger.debug({
     at: "Finalizer#LineaL2ToL1Finalizer",
     message: "Linea TokensBridged event filter",

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -13,6 +13,8 @@ import {
   getRedisCache,
   getBlockForTimestamp,
   getL1TokenInfo,
+  compareAddressesSimple,
+  TOKEN_SYMBOLS_MAP,
 } from "../../utils";
 import { EthersError, TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
@@ -110,6 +112,12 @@ async function getFinalizableTransactions(
   const exitStatus = await Promise.all(
     checkpointedTokensBridged.map(async (_, i) => {
       const payload = payloads[i];
+      const { chainId, l2TokenAddress } = tokensBridged[i];
+
+      if (compareAddressesSimple(l2TokenAddress, TOKEN_SYMBOLS_MAP._USDC.addresses[chainId])) {
+        return { status: "NON_CANONICAL_BRIDGE" };
+      }
+
       try {
         // If we can estimate gas for exit transaction call, then we can exit the burn tx, otherwise its likely
         // been processed. Note this will capture mislabel some exit txns that fail for other reasons as "exit


### PR DESCRIPTION
`TokenBridge` events that use CCTP to transfer tokens off Polygon are causing `UNKNOWN` errors to be thrown in the GCP logs. The reasoning is that our simulations are trying to simulate `exit()` with bridge events that did not originate on the canonical bridge. 

We can't directly filter out the `TokenBridge` events before the simulation logic because we need to be aware of potentially multiple events in one transaction for the `getUniqueLogIndex` and the subsequent call to `buildPayloadForExit`.

This PR simply makes these CCTP message have an error code of `NON_CANONICAL_BRIDGE` which prevents the message from actually being simulated and being pushed to the `finalizableMessages` array.

--

Note: this bug is mainly causes noise & shouldn't directly impact finalization since we catch this error and log as a `debug`