### PR TITLE
fix(finalizer): OpStack finalizer filter

### DIFF
--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -55,8 +55,7 @@ export async function opStackFinalizer(
   // - Don't submit proofs for finalizations older than 1 day
   // - Don't try to withdraw tokens that are not past the 7 day challenge period
   const redis = await getRedisCache(logger);
-  const latestBlockToProve = await 
-    getBlockForTimestamp(chainId, getCurrentTime() - 7 * 60 * 60 * 24, undefined, redis);
+  const latestBlockToProve = await getBlockForTimestamp(chainId, getCurrentTime() - 7 * 60 * 60 * 24, undefined, redis);
   const { recentTokensBridgedEvents = [], olderTokensBridgedEvents = [] } = groupBy(
     spokePoolClient.getTokensBridged(),
     (e) => {

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -61,7 +61,7 @@ export async function opStackFinalizer(
     (e) => {
       if (e.blockNumber >= latestBlockToProve) {
         return "recentTokensBridgedEvents";
-      } else if (e.blockNumber <= latestBlockToProve) {
+      } else {
         return "olderTokensBridgedEvents";
       }
     }


### PR DESCRIPTION
Filter for events to finalize is incorrectly only counting events older than 14 days old. This PR changes it to look 
at any events older than 7 days old
