### PR TITLE
refactor(MultiCallerClient): Permit single-chain execution

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -197,7 +197,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
             pendingProposal,
           });
         } else {
-          await clients.multiCallerClient.executeTransactionQueue();
+          await clients.multiCallerClient.executeTxnQueues();
         }
       };
 

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -90,7 +90,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
 
     // Execute queue and check that root bundle is pending:
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
@@ -105,7 +105,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
     // arbitrum gas fees, and 1 to update the exchangeRate to execute the destination chain leaf.
     // console.log(spy.getCall(-1))
     expect(multiCallerClient.transactionCount()).to.equal(4);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // TEST 3:
     // Submit another root bundle proposal and check bundle block range. There should be no leaves in the new range

--- a/test/Dataworker.executeRelayerRefunds.ts
+++ b/test/Dataworker.executeRelayerRefunds.ts
@@ -69,13 +69,13 @@ describe("Dataworker: Execute relayer refunds", async function () {
     await dataworkerInstance.proposeRootBundle(spokePoolClients);
 
     // Execute queue and check that root bundle is pending:
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Advance time and execute rebalance leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
     await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, await getNewBalanceAllocator());
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Manually relay the roots to spoke pools since adapter is a dummy and won't actually relay messages.
     await updateAllClients();
@@ -90,7 +90,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
     // Note: without sending tokens, only one of the leaves will be executable.
     // This is the leaf with the deposit that is being pulled back to the hub pool.
     expect(multiCallerClient.transactionCount()).to.equal(1);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     await updateAllClients();
 
@@ -101,7 +101,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
     // The other transaction should now be enqueued.
     expect(multiCallerClient.transactionCount()).to.equal(1);
 
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
   });
   describe("Computing refunds for bundles", function () {
     let relayer: SignerWithAddress;
@@ -132,7 +132,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
     it("No validated bundle refunds", async function () {
       // Propose a bundle:
       await dataworkerInstance.proposeRootBundle(spokePoolClients);
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
       await updateAllClients();
 
       // No bundle is validated so no refunds.
@@ -145,13 +145,13 @@ describe("Dataworker: Execute relayer refunds", async function () {
       await updateAllClients();
       // Propose a bundle:
       await dataworkerInstance.proposeRootBundle(spokePoolClients);
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
 
       // Advance time and execute leaves:
       await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
       await updateAllClients();
       await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, await getNewBalanceAllocator());
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
 
       // Before relayer refund leaves are not executed, should have pending refunds:
       await updateAllClients();
@@ -183,7 +183,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       // Execute relayer refund leaves. Send funds to spoke pools to execute the leaves.
       await erc20_2.mint(spokePool_2.address, amountToDeposit);
       await dataworkerInstance.executeRelayerRefundLeaves(spokePoolClients, await getNewBalanceAllocator());
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
 
       // Should now have zero pending refunds
       await updateAllClients();
@@ -216,11 +216,11 @@ describe("Dataworker: Execute relayer refunds", async function () {
 
       // Validate another bundle:
       await dataworkerInstance.proposeRootBundle(spokePoolClients);
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
       await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
       await updateAllClients();
       await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, await getNewBalanceAllocator());
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
       await updateAllClients();
 
       expect(hubPoolClient.getValidatedRootBundles().length).to.equal(2);
@@ -243,7 +243,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
 
       // Propose a bundle:
       await dataworkerInstance.proposeRootBundle(spokePoolClients);
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
       await updateAllClients();
 
       // After proposal but before execution should show upcoming refund:
@@ -260,7 +260,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
       await updateAllClients();
       await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, await getNewBalanceAllocator());
-      await multiCallerClient.executeTransactionQueue();
+      await multiCallerClient.executeTxnQueues();
 
       // Should reset to no refunds in "next bundle", though these will show up in pending bundle.
       await updateAllClients();

--- a/test/Dataworker.executeSlowRelay.ts
+++ b/test/Dataworker.executeSlowRelay.ts
@@ -186,7 +186,7 @@ describe("Dataworker: Execute slow relays", async function () {
     // Execute queue and check that root bundle is pending:
     expect(multiCallerClient.transactionCount()).to.equal(1);
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     const providers = {
       ...spokePoolClientsToProviders(spokePoolClients),
@@ -196,7 +196,7 @@ describe("Dataworker: Execute slow relays", async function () {
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
     await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Manually relay the roots to spoke pools since adapter is a dummy and won't actually relay messages.
     await updateAllClients();

--- a/test/Dataworker.executeSlowRelay.ts
+++ b/test/Dataworker.executeSlowRelay.ts
@@ -68,7 +68,7 @@ describe("Dataworker: Execute slow relays", async function () {
     // Execute queue and check that root bundle is pending:
     expect(multiCallerClient.transactionCount()).to.equal(1);
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     const providers = {
       ...spokePoolClientsToProviders(spokePoolClients),
@@ -79,7 +79,7 @@ describe("Dataworker: Execute slow relays", async function () {
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
     await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Manually relay the roots to spoke pools since adapter is a dummy and won't actually relay messages.
     await updateAllClients();
@@ -97,7 +97,7 @@ describe("Dataworker: Execute slow relays", async function () {
     await dataworkerInstance.executeSlowRelayLeaves(spokePoolClients, new BalanceAllocator(providers));
 
     expect(multiCallerClient.transactionCount()).to.equal(1);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     await updateAllClients();
     const fills = spokePoolClients[destinationChainId].getFills();
@@ -126,7 +126,7 @@ describe("Dataworker: Execute slow relays", async function () {
     // Execute queue and check that root bundle is pending:
     expect(multiCallerClient.transactionCount()).to.equal(1);
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     const providers = {
       ...spokePoolClientsToProviders(spokePoolClients),
@@ -137,7 +137,7 @@ describe("Dataworker: Execute slow relays", async function () {
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
     await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Manually relay the roots to spoke pools since adapter is a dummy and won't actually relay messages.
     await updateAllClients();

--- a/test/Dataworker.proposeRootBundle.ts
+++ b/test/Dataworker.proposeRootBundle.ts
@@ -96,7 +96,7 @@ describe("Dataworker: Propose root bundle", async function () {
 
     // Execute queue and check that root bundle is pending:
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
     await updateAllClients();
     expect(hubPoolClient.hasPendingProposal()).to.equal(true);
 
@@ -162,7 +162,7 @@ describe("Dataworker: Propose root bundle", async function () {
     expect(spy.getCall(-1).lastArg.slowRelayRoot).to.equal(expectedSlowRelayRefundRoot4.tree.getHexRoot());
 
     // Execute queue and check that root bundle is pending:
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
     await updateAllClients();
     expect(hubPoolClient.hasPendingProposal()).to.equal(true);
 

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -98,7 +98,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await dataworkerInstance.buildSlowRelayRoot(blockRange2, spokePoolClients);
     await dataworkerInstance.proposeRootBundle(spokePoolClients);
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Exit early if no pending bundle. There shouldn't be a bundle seen yet because we haven't passed enough blocks
     // beyond the block buffer.
@@ -138,7 +138,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     }
     await updateAllClients();
     await dataworkerInstance.proposeRootBundle(spokePoolClients);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Constructs same roots as proposed root bundle
     await updateAllClients();
@@ -191,7 +191,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     expect(spy.getCall(-2).lastArg.message).to.equal(
       "A bundle end block is < expected start block, submitting dispute"
     );
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Bundle range end blocks are above latest block but within buffer, should skip.
     await updateAllClients();
@@ -231,7 +231,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     expect(spy.getCall(-2).lastArg.message).to.equal(
       "A bundle end block is > latest block + buffer for its chain, submitting dispute"
     );
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Bundle range length doesn't match expected chain ID list.
     await updateAllClients();
@@ -246,7 +246,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected bundle block range length, disputing");
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // PoolRebalance root is empty
     await updateAllClients();
@@ -260,7 +260,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Empty pool rebalance root, submitting dispute");
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // PoolRebalance leaf count is too high
     await updateAllClients();
@@ -275,7 +275,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected pool rebalance root, submitting dispute");
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // PoolRebalance root is off
     await updateAllClients();
@@ -289,7 +289,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected pool rebalance root, submitting dispute");
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // RelayerRefund root is off
     await updateAllClients();
@@ -303,7 +303,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected relayer refund root, submitting dispute");
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // SlowRelay root is off
     await updateAllClients();
@@ -317,7 +317,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected slow relay root, submitting dispute");
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
   });
   it("Validates root bundle with large bundleEvaluationBlockNumbers", async function () {
     await updateAllClients();

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -262,7 +262,7 @@ describe("Monitor", async function () {
     // Have the data worker propose a new bundle.
     await dataworkerInstance.proposeRootBundle(spokePoolClients);
     await l1Token.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // While the new bundle is still pending, refunds are in the "next" category
     await updateAllClients();
@@ -309,7 +309,7 @@ describe("Monitor", async function () {
     };
     await monitorInstance.update();
     await dataworkerInstance.executeRelayerRefundLeaves(spokePoolClients, new BalanceAllocator(providers));
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Now, pending refunds should be 0.
     await monitorInstance.update();
@@ -355,7 +355,7 @@ describe("Monitor", async function () {
     // Have the data worker propose a new bundle.
     await dataworkerInstance.proposeRootBundle(spokePoolClients);
     await l1Token.approve(hubPool.address, MAX_UINT_VAL);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     // Execute pool rebalance leaves.
     await executeBundle(hubPool);
@@ -443,7 +443,7 @@ describe("Monitor", async function () {
     await _monitor.refillBalances();
 
     expect(multiCallerClient.transactionCount()).to.equal(1);
-    await multiCallerClient.executeTransactionQueue();
+    await multiCallerClient.executeTxnQueues();
 
     expect(await spokePool_1.provider.getBalance(spokePool_1.address)).to.equal(toBNWei("2"));
   });

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -266,8 +266,8 @@ describe("MultiCallerClient", async function () {
       expect(multiCaller.transactionCount()).to.equal(nTxns * 2 * chainIds.length);
 
       // Note: Half of the txns should be consolidated into a single multicall txn.
-      const results: string[] = await multiCaller.executeTransactionQueue();
-      expect(results.length).to.equal(fail ? 0 : (nTxns + 1) * chainIds.length);
+      const results = await multiCaller.executeTxnQueues();
+      expect(Object.values(results).flat().length).to.equal(fail ? 0 : (nTxns + 1) * chainIds.length);
     }
   });
 


### PR DESCRIPTION
This permits a single chain to have its queue executed, returning a single array of transaction hashes. This is a prerequisite for a relayer change to further decouple per-chain execution.