### PR TITLE
fix(ZkSyncAdapter): Set correct search fromBlock after update

### DIFF
--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -155,7 +155,7 @@ export class ZKSyncAdapter extends BaseAdapter {
     });
 
     this.baseL1SearchConfig.fromBlock = l1SearchConfig.toBlock + 1;
-    this.baseL1SearchConfig.fromBlock = l2SearchConfig.toBlock + 1;
+    this.baseL2SearchConfig.fromBlock = l2SearchConfig.toBlock + 1;
 
     return this.computeOutstandingCrossChainTransfers(l1Tokens);
   }


### PR DESCRIPTION
This probably has no effect when the relayer doesn't loop, but it does cause problems in looping mode.