### PR TITLE
chore(finalizer): remove lookback constraints

### DIFF
--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -31,7 +31,7 @@ export async function arbitrumOneFinalizer(
 
   // Arbitrum takes 7 days to finalize withdrawals, so don't look up events younger than that.
   const redis = await getRedisCache(logger);
-  const earliestBlockToFinalize = await getBlockForTimestamp(
+  const latestBlockToFinalize = await getBlockForTimestamp(
     chainId,
     getCurrentTime() - 7 * 60 * 60 * 24,
     undefined,
@@ -40,12 +40,12 @@ export async function arbitrumOneFinalizer(
   logger.debug({
     at: "Finalizer#ArbitrumFinalizer",
     message: "Arbitrum TokensBridged event filter",
-    toBlock: earliestBlockToFinalize,
+    toBlock: latestBlockToFinalize,
   });
   // Skip events that are likely not past the seven day challenge period.
   const olderTokensBridgedEvents = spokePoolClient
     .getTokensBridged()
-    .filter((e) => e.blockNumber <= earliestBlockToFinalize);
+    .filter((e) => e.blockNumber <= latestBlockToFinalize);
 
   return await multicallArbitrumFinalizations(olderTokensBridgedEvents, signer, hubPoolClient, logger);
 }

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -46,7 +46,7 @@ export async function zkSyncFinalizer(
   // Zksync takes 1 day to finalize so ignore any events
   // earlier than 1 day.
   const redis = await getRedisCache(logger);
-  const earliestBlockToFinalize = await getBlockForTimestamp(
+  const latestBlockToFinalize = await getBlockForTimestamp(
     l2ChainId,
     getCurrentTime() - 1 * 60 * 60 * 24,
     undefined,
@@ -56,11 +56,11 @@ export async function zkSyncFinalizer(
   logger.debug({
     at: "Finalizer#ZkSyncFinalizer",
     message: "ZkSync TokensBridged event filter",
-    toBlock: earliestBlockToFinalize,
+    toBlock: latestBlockToFinalize,
   });
   const withdrawalsToQuery = spokePoolClient
     .getTokensBridged()
-    .filter(({ blockNumber }) => blockNumber <= earliestBlockToFinalize);
+    .filter(({ blockNumber }) => blockNumber <= latestBlockToFinalize);
   const statuses = await sortWithdrawals(l2Provider, withdrawalsToQuery);
   const l2Finalized = statuses["finalized"] ?? [];
   const candidates = await filterMessageLogs(wallet, l2Finalized);

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -44,21 +44,23 @@ export async function zkSyncFinalizer(
   const wallet = new zkWallet((signer as Wallet).privateKey, l2Provider, l1Provider);
 
   // Zksync takes 1 day to finalize so ignore any events
-  // older than 2 days and earlier than 1 day.
+  // earlier than 1 day.
   const redis = await getRedisCache(logger);
-  const [fromBlock, toBlock] = await Promise.all([
-    getBlockForTimestamp(l2ChainId, getCurrentTime() - 8 * 60 * 60 * 24, undefined, redis),
-    getBlockForTimestamp(l2ChainId, getCurrentTime() - 1 * 60 * 60 * 24, undefined, redis),
-  ]);
+  const earliestBlockToFinalize = await getBlockForTimestamp(
+    l2ChainId,
+    getCurrentTime() - 1 * 60 * 60 * 24,
+    undefined,
+    redis
+  );
+
   logger.debug({
     at: "Finalizer#ZkSyncFinalizer",
     message: "ZkSync TokensBridged event filter",
-    fromBlock,
-    toBlock,
+    toBlock: earliestBlockToFinalize,
   });
   const withdrawalsToQuery = spokePoolClient
     .getTokensBridged()
-    .filter(({ blockNumber }) => blockNumber >= fromBlock && blockNumber <= toBlock);
+    .filter(({ blockNumber }) => blockNumber <= earliestBlockToFinalize);
   const statuses = await sortWithdrawals(l2Provider, withdrawalsToQuery);
   const l2Finalized = statuses["finalized"] ?? [];
   const candidates = await filterMessageLogs(wallet, l2Finalized);


### PR DESCRIPTION
I propose we can bound the lookback on `ZKSync` and `Arbitrum` to be withdrawals with the latest block being each respective lockup window and the earliest block being decided by `FINALIZER_MAX_TOKENBRIDGE_LOOKBACK`