### PR TITLE
fix(ArbitrumFinalizer): Ignore TokensBridged events without corresponding StandardBridge outbound transfers

### DIFF
--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -45,7 +45,11 @@ export async function arbitrumOneFinalizer(
   // Skip events that are likely not past the seven day challenge period.
   const olderTokensBridgedEvents = spokePoolClient
     .getTokensBridged()
-    .filter((e) => e.blockNumber <= latestBlockToFinalize);
+    .filter(
+      (e) =>
+        e.blockNumber <= latestBlockToFinalize &&
+        !compareAddressesSimple(e.l2TokenAddress, TOKEN_SYMBOLS_MAP["_USDC"].addresses[CHAIN_ID])
+    );
 
   return await multicallArbitrumFinalizations(olderTokensBridgedEvents, signer, hubPoolClient, logger);
 }
@@ -154,11 +158,7 @@ async function getAllMessageStatuses(
         };
       })
       // USDC withdrawals for Arbitrum should be finalized via the CCTP Finalizer.
-      .filter(
-        (result) =>
-          result.message !== undefined &&
-          !compareAddressesSimple(result.info.l2TokenAddress, TOKEN_SYMBOLS_MAP["_USDC"].addresses[CHAIN_ID])
-      )
+      .filter((result) => result.message !== undefined)
   );
 }
 


### PR DESCRIPTION
The current code will log a `warn` message for L2 SpokePool withdrawals containing two or more `TokensBridged` events where any ERC20 withdrawals follow USDC-CCTP withdrawals. This results in those ERC20 withdrawals being ignored by the finalizer. I ran this code locally to finalize a DAI withdrawal that should already have been finalized.

Here's the example `warn` log for a DAI `TokensBridged` event following an already finalized L2->L1 CCTP Finalizer that motivates this fix:

You can see that the `logIndex` for the DAI withdrawal is 1, but the `l2ToL1Messages` count is also 1. This results in [this line](https://github.com/across-protocol/relayer-v3/blob/b7e38c1fe79c44c2e25ad87904ac92920cec7179/src/finalizer/utils/arbitrum.ts#L180) being triggered and the DAI withdrawal is skipped.

This [L2 transaction](https://arbiscan.io/tx/0x7ac7c7a3fe3519bc31d1b2243054f60decb9e61341c4b4d4d08c1b56dad85885#eventlog) contains two L2 to L1 withdrawals: USDC via CCTP at log index 82 and a DAI withdrawal via the standard bridge at 94.

The bug is that the line [here](https://github.com/across-protocol/relayer-v3/blob/b7e38c1fe79c44c2e25ad87904ac92920cec7179/src/finalizer/utils/arbitrum.ts#L179) returns that there is one L2 to L1 message, *because the Arbitrum SDK does not count the USDC CCTP withdrawal as an L2 to L1 message*. But, the `logIndex` for the DAI withdrawal is set to 1 (out of 2: [0,1]) [here](https://github.com/across-protocol/relayer-v3/blob/b7e38c1fe79c44c2e25ad87904ac92920cec7179/src/finalizer/utils/arbitrum.ts#L143).

Therefore, the fix to takes into account how `getUniqueLogIndex()` works and filters out any `TokensBridged` events containing USDC withdrawals before calling `getAllMessageStatuses()` (which calls `getUniqueLogIndex()`).
