### PR TITLE
improve(Monitor): Allow stuck rebalance monitor grace period to be configured

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -40,7 +40,10 @@ import { MonitorClients, updateMonitorClients } from "./MonitorClientHelper";
 import { MonitorConfig } from "./MonitorConfig";
 import { CombinedRefunds } from "../dataworker/DataworkerUtils";
 
-export const REBALANCE_FINALIZE_GRACE_PERIOD = 40 * 60; // 40 minutes, which is 50% of the way through an 80 minute
+export const REBALANCE_FINALIZE_GRACE_PERIOD = Number(process.env.REBALANCE_FINALIZE_GRACE_PERIOD) ?? 60 * 60;
+// 60 minutes, which is the length of the challenge window, so if a rebalance takes longer than this to finalize,
+// then its finalizing after the subsequent challenge period has started, which is sub-optimal.
+
 // bundle frequency.
 export const ALL_CHAINS_NAME = "All chains";
 const ALL_BALANCE_TYPES = [

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -40,7 +40,9 @@ import { MonitorClients, updateMonitorClients } from "./MonitorClientHelper";
 import { MonitorConfig } from "./MonitorConfig";
 import { CombinedRefunds } from "../dataworker/DataworkerUtils";
 
-export const REBALANCE_FINALIZE_GRACE_PERIOD = Number(process.env.REBALANCE_FINALIZE_GRACE_PERIOD) ?? 60 * 60;
+export const REBALANCE_FINALIZE_GRACE_PERIOD = process.env.REBALANCE_FINALIZE_GRACE_PERIOD
+  ? Number(process.env.REBALANCE_FINALIZE_GRACE_PERIOD)
+  : 60 * 60;
 // 60 minutes, which is the length of the challenge window, so if a rebalance takes longer than this to finalize,
 // then its finalizing after the subsequent challenge period has started, which is sub-optimal.
 


### PR DESCRIPTION
Resets default to 60 mins, and reads from process.env. where possible
