### PR TITLE
improve(relayer): Ignore deposits for disabled destination chains

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -217,15 +217,18 @@ export class Relayer {
    */
   private _getUnfilledDeposits(): Record<number, RelayerUnfilledDeposit[]> {
     const { hubPoolClient, spokePoolClients } = this.clients;
+    const { relayerDestinationChains } = this.config;
 
     // Filter the resulting deposits according to relayer configuration.
     return Object.fromEntries(
-      Object.values(spokePoolClients).map(({ chainId: destinationChainId }) => [
-        destinationChainId,
-        getUnfilledDeposits(destinationChainId, spokePoolClients, hubPoolClient).filter((deposit) =>
-          this.filterDeposit(deposit)
-        ),
-      ])
+      Object.values(spokePoolClients)
+        .filter(({ chainId }) => relayerDestinationChains?.includes(chainId) ?? true)
+        .map(({ chainId: destinationChainId }) => [
+          destinationChainId,
+          getUnfilledDeposits(destinationChainId, spokePoolClients, hubPoolClient).filter((deposit) =>
+            this.filterDeposit(deposit)
+          ),
+        ])
     );
   }
 

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -117,9 +117,8 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
       relayerClients.profitClient.clearUnprofitableFills();
       relayerClients.tokenClient.clearTokenShortfall();
 
-      const tLoopStop = performance.now();
-      const runTime = Math.round((tLoopStop - tLoopStart) / 1000);
       if (loop) {
+        const runTime = Math.round((performance.now() - tLoopStart) / 1000);
         logger.debug({
           at: "Relayer#run",
           message: `Completed relayer execution loop ${run++} in ${runTime} seconds.`,

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -310,9 +310,6 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       await updateAllClients();
       const txnReceipts = await relayerInstance.checkForUnfilledDepositsAndFill();
       Object.values(txnReceipts).forEach((receipts) => expect(receipts.length).to.equal(0));
-      expect(
-        spy.getCalls().find(({ lastArg }) => lastArg.message.includes("Skipping deposit from or to disabled chains"))
-      ).to.not.be.undefined;
     });
 
     it("Correctly validates self-relays", async function () {

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -158,7 +158,6 @@ describe("Relayer: Initiates slow fill requests", async function () {
       {
         relayerTokens: [],
         slowDepositors: [],
-        relayerDestinationChains: [],
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig
     );

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -161,7 +161,6 @@ describe("Relayer: Token balance shortfall", async function () {
       {
         relayerTokens: [],
         slowDepositors: [],
-        relayerDestinationChains: [],
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig
     );

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -131,7 +131,6 @@ describe("Relayer: Unfilled Deposits", async function () {
       },
       {
         relayerTokens: [],
-        relayerDestinationChains: [],
         minDepositConfirmations: defaultMinDepositConfirmations,
         acceptInvalidFills: false,
       } as unknown as RelayerConfig


### PR DESCRIPTION
Failing to do this can produce a lot of log spam that is ultimately unnecessary.