### PR TITLE
fix(RelayerConfig): Read symbol not address

### DIFF
--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -178,7 +178,7 @@ export class RelayerConfig extends CommonConfig {
         tokenConfig.targetOverageBuffer = toBNWei(targetOverageBuffer ?? "1.5");
 
         // For WETH, also consider any unwrap target/threshold.
-        if (l1Token === TOKEN_SYMBOLS_MAP.WETH.addresses[this.hubPoolChainId]) {
+        if (l1Token === TOKEN_SYMBOLS_MAP.WETH.symbol) {
           if (unwrapWethThreshold !== undefined) {
             tokenConfig.unwrapWethThreshold = toBNWei(unwrapWethThreshold);
           }


### PR DESCRIPTION
Bug found because `unwrapWethThreshold` in rebalancer seemed to be getting ignored, turned out it was never getting parsed because this line was always false
