### PR TITLE
improve(relayer): Persist fillStatus across loops

### DIFF
--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -1,8 +1,15 @@
 import * as contracts from "@across-protocol/contracts-v2/dist/test-utils";
 import { ExpandedERC20__factory as ERC20 } from "@across-protocol/contracts-v2";
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
-import { AcrossApiClient, ConfigStoreClient, HubPoolClient, MultiCallerClient, SpokePoolClient, TokenClient } from "../src/clients";
-import { DepositWithBlock } from "../src/interfaces";
+import {
+  AcrossApiClient,
+  ConfigStoreClient,
+  HubPoolClient,
+  MultiCallerClient,
+  SpokePoolClient,
+  TokenClient,
+} from "../src/clients";
+import { DepositWithBlock, FillStatus } from "../src/interfaces";
 import {
   CHAIN_ID_TEST_LIST,
   amountToLp,
@@ -34,7 +41,7 @@ import {
 // Tested
 import { Relayer } from "../src/relayer/Relayer";
 import { RelayerConfig } from "../src/relayer/RelayerConfig";
-import { RelayerUnfilledDeposit, getAllUnfilledDeposits, utf8ToHex } from "../src/utils";
+import { RelayerUnfilledDeposit, getAllUnfilledDeposits, getUnfilledDeposits, utf8ToHex } from "../src/utils";
 
 describe("Relayer: Unfilled Deposits", async function () {
   const { bnOne } = sdkUtils;
@@ -45,6 +52,7 @@ describe("Relayer: Unfilled Deposits", async function () {
 
   let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
   let configStoreClient: MockConfigStoreClient, hubPoolClient: HubPoolClient;
+  let spokePoolClients: Record<number, SpokePoolClient>;
   let multiCallerClient: MultiCallerClient, tokenClient: TokenClient;
   let profitClient: MockProfitClient;
   let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
@@ -109,7 +117,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       { fromBlock: 0, toBlock: undefined, maxBlockLookBack: 0 }
     );
 
-    const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
+    spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     multiCallerClient = new MockedMultiCallerClient(spyLogger);
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
@@ -184,6 +192,46 @@ describe("Relayer: Unfilled Deposits", async function () {
       .to.deep.equal(
         [...deposits]
           .sort((a, b) => (a.destinationChainId > b.destinationChainId ? 1 : -1))
+          .map((deposit) => ({
+            deposit,
+            unfilledAmount: deposit.outputAmount,
+            invalidFills: [],
+            version: configStoreClient.configStoreVersion,
+          }))
+      );
+  });
+
+  it("Correctly uses input fill status", async function () {
+    const deposits: DepositWithBlock[] = [];
+    for (let i = 0; i < 5; ++i) {
+      const deposit = await depositV3(
+        spokePool_1,
+        destinationChainId,
+        depositor,
+        erc20_1.address,
+        inputAmount,
+        erc20_2.address,
+        outputAmount
+      );
+      deposits.push(deposit);
+    }
+    await updateAllClients();
+
+    // Take the 2nd last deposit and mark it filled.
+    expect(deposits.length > 2).to.be.true;
+    const filledDeposit = deposits.at(-2);
+    expect(filledDeposit).to.exist;
+
+    const depositHash = spokePoolClient_1.getDepositHash(filledDeposit!);
+    const { fillStatus } = relayerInstance;
+    fillStatus[depositHash] = FillStatus.Filled;
+
+    unfilledDeposits = getUnfilledDeposits(destinationChainId, spokePoolClients, hubPoolClient, fillStatus);
+    expect(unfilledDeposits)
+      .excludingEvery(["realizedLpFeePct", "quoteBlockNumber"])
+      .to.deep.equal(
+        deposits
+          .filter(({ depositId }) => depositId !== filledDeposit!.depositId)
           .map((deposit) => ({
             deposit,
             unfilledAmount: deposit.outputAmount,


### PR DESCRIPTION
The looping relayer is forced to drink from the fire hose when determining the set of unfilled deposits. In times of high demand this can lead to a lot of unnecessary looping and hashing of relayData to filter out deposits that have already been filled. This change adds tracking of fill status across loops in order to permit already-filled deposits to be filtered out as early as possible. There should be limited impact on the initial loop (or when POLLING_MODE=0), but it will have an effect on subsequent loops.